### PR TITLE
feat: focus sidebar, block and resource list

### DIFF
--- a/src/planner2/PlannerCanvas.tsx
+++ b/src/planner2/PlannerCanvas.tsx
@@ -11,6 +11,7 @@ import { ZoomButtons } from '../components/ZoomButtons';
 import { ZOOM_STEP_SIZE } from './types';
 import { PlannerMode } from '../wrappers/PlannerModelWrapper';
 import { FocusTopbar } from './components/FocusTopbar';
+import { PlannerFocusSideBar } from './components/PlannerFocusSideBar';
 
 const blockPositionUpdater = (diff: PositionDiff, zoom: number) => (block: BlockInstanceSpec) => {
     return {
@@ -55,6 +56,22 @@ export const PlannerCanvas: React.FC<React.PropsWithChildren> = (props) => {
             <div className={focusToolbar}>
                 <FocusTopbar setFocusBlock={planner.setFocusedBlock} focusedBlock={planner.focusedBlock} />
             </div>
+
+            <PlannerFocusSideBar
+                block={planner.focusedBlock}
+                blurFocus={() => {
+                    planner.setFocusedBlock(undefined);
+                }}
+                onBlockItemHover={() => {
+                    // console.log('on block item hover');
+                    // TODO:
+                }}
+                onClose={() => {
+                    planner.setFocusedBlock(undefined);
+                }}
+                onFocusChange={(block) => planner.setFocusedBlock(block)}
+            />
+
             <div className="planner-area-position-parent" ref={onRef}>
                 <DragAndDrop.DropZone
                     scale={planner.zoom}

--- a/src/planner2/PlannerContext.tsx
+++ b/src/planner2/PlannerContext.tsx
@@ -29,7 +29,7 @@ export interface PlannerContextData {
     plan?: PlanKind;
     blockAssets: Asset<BlockKind>[];
     focusedBlock?: BlockInstanceSpec;
-    setFocusedBlock(block: BlockInstanceSpec): void;
+    setFocusedBlock(block: BlockInstanceSpec | undefined): void;
     mode?: PlannerMode;
     zoom: number;
     setZoomLevel: (zoom: number | ((currentZoom: number) => number)) => void;
@@ -80,6 +80,7 @@ const defaultValue: PlannerContextData = {
     getBlockById(blockId: string): BlockKind | undefined {
         return undefined;
     },
+
     updateBlockDefinition() {},
     updateBlockInstance(blockId, callback) {
         // noop
@@ -190,8 +191,8 @@ export const usePlannerContext = (props: PlannerContextProps): PlannerContextDat
     }, [props.onAssetChange, blockAssets, props.blockAssets]);
 
     const toggleFocusBlock = useCallback(
-        (block: BlockInstanceSpec) => {
-            setFocusedBlock((prevFocus) => (prevFocus && block.id === prevFocus.id ? undefined : block));
+        (block: BlockInstanceSpec | undefined) => {
+            setFocusedBlock((prevFocus) => (prevFocus && block && block.id === prevFocus.id ? undefined : block));
         },
         [setFocusedBlock]
     );
@@ -335,6 +336,7 @@ export const usePlannerContext = (props: PlannerContextProps): PlannerContextDat
                 const resource = list?.find((rx) => rx.metadata.name === resourceName);
                 return resource;
             },
+
             // connections
             addConnection({ from, to, mapping }: BlockConnectionSpec) {
                 setPlan((prevState) => {

--- a/src/planner2/components/BlockTree.tsx
+++ b/src/planner2/components/BlockTree.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { BlockInstanceSpec, ResourceKind, ResourceRole } from '@kapeta/ui-web-types';
+import { ResourceTypeProvider } from '@kapeta/ui-web-context';
+
+import { useFocusInfo } from '../utils/focusUtils';
+import { BlockInfo } from '../types';
+
+export interface Props {
+    block: BlockInstanceSpec;
+    onBlockClicked: (block: BlockInstanceSpec) => void;
+    onBlockItemHover: (block?: BlockInstanceSpec) => void;
+}
+
+export interface State {
+    hoveredBlock?: BlockInstanceSpec;
+}
+
+export function BlockTree(props: Props) {
+    const focusInfo = useFocusInfo();
+    const [hoveredBlock, setHoveredBlock] = useState<BlockInfo>();
+
+    function getBlockIcon(block: BlockInstanceSpec) {
+        const isFocused = block.id === props.block.id;
+        if (isFocused) {
+            return (
+                <div className="block-icon">
+                    <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+                        <path
+                            d="M0 2.04279C0 1.80029 0.149066 1.58356 0.373327 1.49999L4.30371 0.0354169C4.43043 -0.0118056 4.56957 -0.0118056 4.69629 0.0354168L8.62667 1.49999C8.85093 1.58356 9 1.80029 9 2.04279V6.90671C9 7.14685 8.85377 7.362 8.6326 7.44726L4.70222 8.96234C4.57195 9.01255 4.42805 9.01255 4.29778 8.96234L0.367399 7.44726C0.146232 7.362 0 7.14685 0 6.90671V2.04279Z"
+                            fill="#DCD8D3"
+                        />
+                        <path
+                            d="M3.19874 4.03146C2.77535 4.18923 2.5 4.59522 2.5 5.04279V9.90671C2.5 10.35 2.77011 10.7529 3.18756 10.9138L7.11794 12.4289C7.36396 12.5237 7.63604 12.5237 7.88206 12.4289L11.8124 10.9138C12.2299 10.7529 12.5 10.35 12.5 9.90671V5.04279C12.5 4.59522 12.2246 4.18923 11.8013 4.03146L7.87088 2.56689C7.63154 2.4777 7.36846 2.4777 7.12912 2.56689L3.19874 4.03146Z"
+                            fill="#DCD8D3"
+                            stroke="#544B49"
+                        />
+                    </svg>
+                </div>
+            );
+        }
+        return (
+            <div className="block-icon">
+                <svg width="11" height="14" viewBox="0 0 11 14" fill="none">
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M4.48146 1.53616L0.814811 2.91155V7.81763L1.22213 7.97569V8.8497L0.365885 8.51744C0.145629 8.43197 0 8.21628 0 7.97553V2.75164C0 2.50853 0.148452 2.29126 0.371789 2.20748L4.28598 0.739241C4.41218 0.6919 4.55074 0.6919 4.67695 0.739241L8.59113 2.20748C8.81447 2.29126 8.96292 2.50853 8.96292 2.75164V4.01475L8.14811 3.71116V2.91155L4.48146 1.53616Z"
+                        fill="#99928F"
+                    />
+                    <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M2.82643 6.15294L6.51854 4.768L10.2107 6.15294V11.0941L6.51854 12.5268L2.82643 11.0941V6.15294ZM10.6282 5.46651C10.8515 5.55029 11 5.76757 11 6.01067V11.2346C11 11.4753 10.8544 11.691 10.6341 11.7765L6.71993 13.2953C6.59019 13.3457 6.44689 13.3457 6.31715 13.2953L2.40296 11.7765C2.18271 11.691 2.03708 11.4753 2.03708 11.2346V6.01067C2.03708 5.76757 2.18553 5.55029 2.40887 5.46651L6.32305 3.99827C6.44926 3.95093 6.58782 3.95093 6.71402 3.99827L10.6282 5.46651Z"
+                        fill="#99928F"
+                    />
+                </svg>
+            </div>
+        );
+    }
+
+    function getResourceIcon(resource: ResourceKind, role: ResourceRole) {
+        const resourceConfig = ResourceTypeProvider.get(resource.kind);
+        const type = resourceConfig.type.toString().toLowerCase();
+
+        if (role === ResourceRole.CONSUMES) {
+            return (
+                <div className={`resource-icon ${type}`}>
+                    <svg
+                        transform="scale(-1, 1)" // mirrors the svg
+                        width="10"
+                        height="11"
+                        viewBox="0 0 10 11"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                            opacity="0.6"
+                            d="M6.98571 10.5285C6.80262 10.8195 6.45524 11 6.07824 11L1.03811 11C0.464779 11 -9.17796e-07 10.5896 -8.73537e-07 10.0833L-7.21614e-08 0.916667C-2.79027e-08 0.410406 0.46478 1.20079e-07 1.03811 1.70201e-07L6.07824 6.10823e-07C6.45525 6.43782e-07 6.80262 0.180485 6.98571 0.471495L9.86936 5.05483C10.0435 5.33168 10.0435 5.66832 9.86936 5.94517L6.98571 10.5285Z"
+                            fill="#CFCBC1"
+                        />
+                    </svg>
+                </div>
+            );
+        }
+        return (
+            <div className={`resource-icon ${type}`}>
+                <svg width="10 " height="11" viewBox="0 0 10 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        opacity="0.6"
+                        d="M6.98571 10.5285C6.80262 10.8195 6.45524 11 6.07824 11L1.03811 11C0.464779 11 -9.17796e-07 10.5896 -8.73537e-07 10.0833L-7.21614e-08 0.916667C-2.79027e-08 0.410406 0.46478 1.20079e-07 1.03811 1.70201e-07L6.07824 6.10823e-07C6.45525 6.43782e-07 6.80262 0.180485 6.98571 0.471495L9.86936 5.05483C10.0435 5.33168 10.0435 5.66832 9.86936 5.94517L6.98571 10.5285Z"
+                        fill="#CFCBC1"
+                    />
+                </svg>
+            </div>
+        );
+    }
+
+    return (
+        <div className="connected-blocks">
+            <div className="focused-block-line">
+                {getBlockIcon(props.block)}
+                <div className="block-name">{props.block.name} </div>
+            </div>
+            {[...(focusInfo?.consumingBlocks || []), ...(focusInfo?.providingBlocks || [])].map((block, index) => {
+                return (
+                    // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+                    <div
+                        key={block.instance.id + index}
+                        className="connected-block-line"
+                        onMouseEnter={() => {
+                            setHoveredBlock(block);
+                            props.onBlockItemHover(block.instance);
+                        }}
+                        onMouseLeave={() => {
+                            setHoveredBlock(undefined);
+                            props.onBlockItemHover(undefined);
+                        }}
+                        onClick={() => {
+                            props.onBlockClicked(block.instance);
+                        }}
+                    >
+                        {getBlockIcon(block.instance)}
+                        <div className="block-name">{block.instance.name} </div>
+                        {hoveredBlock &&
+                            hoveredBlock.instance.id === block.instance.id &&
+                            [
+                                ...(hoveredBlock.block.spec.consumers || []).map((resource) => ({
+                                    resource,
+                                    role: ResourceRole.CONSUMES,
+                                })),
+                                ...(hoveredBlock.block.spec.providers || []).map((resource) => ({
+                                    resource,
+                                    role: ResourceRole.PROVIDES,
+                                })),
+                            ].map(({ resource, role }, ix) => {
+                                return (
+                                    <div
+                                        key={`resource_${ix}`}
+                                        onMouseMove={() => {
+                                            // resource.setMode(ResourceMode.SHOW);
+                                        }}
+                                        onMouseLeave={() => {
+                                            // resource.setMode(ResourceMode.HIDDEN);
+                                        }}
+                                    >
+                                        <div className="resource-icon">{getResourceIcon(resource, role)}</div>
+                                        <div className="resource-name">{resource.metadata.name}</div>
+                                    </div>
+                                );
+                            })}
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/planner2/components/PlannerFocusSideBar.less
+++ b/src/planner2/components/PlannerFocusSideBar.less
@@ -1,0 +1,84 @@
+@import '~@kapeta/ui-web-components/styles/values';
+@import '~@kapeta/ui-web-components/styles/functions';
+
+.focus-side-panel-2 {
+    .side-panel-container.small {
+        background-color: @gray-xdark;
+        width: 300px;
+        top: 0px;
+        color: @bw-planner-background;
+    }
+
+    .side-panel-header-icon {
+        align-content: center;
+    }
+
+    p {
+        color: @bw-planner-background;
+        font-style: normal;
+        font-weight: 500;
+        font-size: 16px;
+        line-height: 24px;
+    }
+
+    .focused-block-line {
+        .transition();
+        padding-top: 10px;
+        padding-bottom: 10px;
+
+        .block-icon {
+            display: inline-flex;
+            margin-right: 12px;
+        }
+
+        .block-name {
+            display: inline;
+        }
+    }
+
+    .connected-blocks {
+        color: @bw-planner-background;
+        padding: 5px;
+
+        .connected-block-line {
+            cursor: pointer;
+            .transition();
+            padding-top: 10px;
+
+            .block-icon {
+                display: inline-flex;
+                margin-right: 12px;
+            }
+
+            .block-name {
+                display: inline;
+            }
+
+            .resource-icon {
+                left: 0;
+                display: inline-flex;
+                padding: 5px;
+
+                &.database {
+                    svg {
+                        path {
+                            fill: @bw-green;
+                        }
+                    }
+                }
+
+                &.service {
+                    svg {
+                        path {
+                            fill: @bw-orange;
+                        }
+                    }
+                }
+            }
+
+            .resource-name {
+                display: inline;
+            }
+        }
+    }
+}

--- a/src/planner2/components/PlannerFocusSideBar.tsx
+++ b/src/planner2/components/PlannerFocusSideBar.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { SidePanel, PanelAlignment, PanelSize, SidePanelHeader } from '@kapeta/ui-web-components';
+
+import { BlockTree } from './BlockTree';
+
+import './PlannerFocusSideBar.less';
+import { BlockInstanceSpec } from '@kapeta/ui-web-types';
+
+interface Props {
+    block?: BlockInstanceSpec;
+    blurFocus: () => void;
+    onBlockItemHover: (block?: BlockInstanceSpec) => void;
+    onClose: () => void;
+    onFocusChange: (block: BlockInstanceSpec) => void;
+}
+
+export const PlannerFocusSideBar = (props: Props) => {
+    return (
+        <SidePanel
+            title="Blocks in view"
+            closable={false}
+            className="focus-side-panel-2"
+            open={!!props.block}
+            side={PanelAlignment.right}
+            size={PanelSize.small}
+            onClose={props.onClose}
+            header={
+                <SidePanelHeader
+                    title="Blocks in use"
+                    onIconPress={props.blurFocus}
+                    icon={
+                        <svg width="7" height="12" viewBox="0 0 7 12" fill="none">
+                            <path d="M6.05054 11L0.999978 5.94974" stroke="#F5F1EE" strokeLinecap="round" />
+                            <path d="M1 5.94971L6.05025 0.999976" stroke="#F5F1EE" strokeLinecap="round" />
+                        </svg>
+                    }
+                />
+            }
+        >
+            {props.block && (
+                <BlockTree
+                    onBlockItemHover={props.onBlockItemHover}
+                    onBlockClicked={(block) => {
+                        props.onFocusChange(block);
+                    }}
+                    block={props.block}
+                />
+            )}
+        </SidePanel>
+    );
+};


### PR DESCRIPTION
We are now listing the blocks and resources, but need to add the hover to expand.
It's a little unclear where to put the state for this, since the resource no longer has display state on itself.

![Screenshot 2023-04-04 at 16 11 32](https://user-images.githubusercontent.com/296057/229820098-9264b067-8d83-4269-9926-984857d043fc.png)

