### PR TITLE
fix: restore updateBlockDefinition in planner

### DIFF
--- a/src/planner/PlannerContext.tsx
+++ b/src/planner/PlannerContext.tsx
@@ -443,7 +443,7 @@ export const usePlannerContext = (props: PlannerContextProps): PlannerContextDat
             updateBlockAssets((state) =>
                 state.map((block) =>
                     parseKapetaUri(block.ref).equals(uri)
-                        ? { ...block, ref: `kapeta://${update.metadata.name}:local`, data: update }
+                        ? { ...block, ref: `kapeta://${update.metadata.name}:local`, content: update }
                         : block
                 )
             );


### PR DESCRIPTION
Fixes a bug that was introduced when converting to simpler asset info wrappers in release 1.0.0.