### PR TITLE
Avoid 0 rendered as text

### DIFF
--- a/src/components/AssetThumbnail.tsx
+++ b/src/components/AssetThumbnail.tsx
@@ -182,7 +182,7 @@ export const AssetThumbnailContainer = forwardRef<HTMLDivElement, AssetThumbnail
                         </Typography>
                     )}
                 </Box>
-                {props.stats?.length && (
+                {props.stats?.length ? (
                     <Box>
                         {props.stats.map((stat, index) => {
                             const renderedStat = (
@@ -212,7 +212,7 @@ export const AssetThumbnailContainer = forwardRef<HTMLDivElement, AssetThumbnail
                             );
                         })}
                     </Box>
-                )}
+                ) : null}
             </Stack>
         </Stack>
     );


### PR DESCRIPTION
A 0 was rendered to the DOM if `stats={[]}`