### PR TITLE
KAP-1671 Add kap ids for instrumentation and tests

### DIFF
--- a/src/components/AssetThumbnail.tsx
+++ b/src/components/AssetThumbnail.tsx
@@ -102,6 +102,7 @@ export const AssetThumbnailContainer = forwardRef<HTMLDivElement, AssetThumbnail
             <Box className="preview" flex={1}>
                 {props.installerService?.uninstall && (
                     <Chip
+                        data-kap-id="asset-thumbnail-delete-button"
                         label={deleting ? <CircularProgress size={24} /> : <Delete />}
                         variant="filled"
                         color="default"

--- a/src/components/GatewayCard.tsx
+++ b/src/components/GatewayCard.tsx
@@ -117,6 +117,7 @@ export const GatewayCard = (props: GatewayCardProps) => {
                             )}
                             <KapTooltip arrow title={`${entry?.url}`}>
                                 <a
+                                    data-kap-id="open-gateway-url"
                                     href={entry?.url}
                                     target="_blank"
                                     rel="noopener noreferrer"
@@ -164,7 +165,7 @@ export const GatewayCard = (props: GatewayCardProps) => {
                         <circle cx={4} cy={8} r={4} fill="currentColor" />
                     </Box>
                 </KapTooltip>
-                <IconButton onClick={(e) => setMenuRef(e.currentTarget)}>
+                <IconButton onClick={(e) => setMenuRef(e.currentTarget)} data-kap-id="gateway-context-menu">
                     <MoreVert />
                 </IconButton>
             </Stack>
@@ -185,6 +186,7 @@ export const GatewayCard = (props: GatewayCardProps) => {
                         props.onConfigureGateway?.();
                         setMenuRef(null);
                     }}
+                    data-kap-id="configure-gateway"
                 >
                     Configure
                 </MenuItem>
@@ -196,6 +198,7 @@ export const GatewayCard = (props: GatewayCardProps) => {
                         href={props.primary?.url || ''}
                         disabled={!props.primary?.url}
                         onClick={() => setMenuRef(null)}
+                        data-kap-id="open-custom-url"
                     >
                         Open custom URL
                     </MenuItem>
@@ -207,6 +210,7 @@ export const GatewayCard = (props: GatewayCardProps) => {
                     href={props.fallback?.url || ''}
                     disabled={!props.fallback?.url}
                     onClick={() => setMenuRef(null)}
+                    data-kap-id="open-kapeta-url"
                 >
                     {fallbackText}
                 </MenuItem>

--- a/src/components/PlannerBlockWarningTag.tsx
+++ b/src/components/PlannerBlockWarningTag.tsx
@@ -59,6 +59,7 @@ export const PlannerBlockWarningTag = forwardRef<SVGSVGElement, PlannerBlockWarn
                             width={25}
                             height={40}
                             onClick={props.onClick}
+                            data-kap-id="planner-block-warning-tag"
                         >
                             <defs>
                                 <filter id="banner-shadow" x="-100%" y="-100%" width="300%" height="300%">

--- a/src/components/ResourceShape.tsx
+++ b/src/components/ResourceShape.tsx
@@ -83,6 +83,8 @@ export const ResourceShape = (props: Props) => {
 
     return (
         <Box
+            data-kap-id="draggable-resource-shape"
+            className={`kap-resource-shape ${props.resource.type}`}
             onMouseDown={props.onMouseDown}
             style={{
                 left: props.position?.x,

--- a/src/panels/BlockInspectorPanel.tsx
+++ b/src/panels/BlockInspectorPanel.tsx
@@ -56,8 +56,12 @@ export const BlockInspectorPanel = (props: BlockInspectorPanelProps) => {
                     }}
                 >
                     <Tabs value={tab} onChange={(evt, newTabId) => setTab(newTabId)}>
-                        {props.emitter && <Tab label={'Logs'} value={'logs'} />}
-                        <Tab label={`Issues (${issues.length})`} value={'issues'} />
+                        {props.emitter && <Tab label={'Logs'} value={'logs'} data-kap-id="block-inspector-log-tab" />}
+                        <Tab
+                            label={`Issues (${issues.length})`}
+                            value={'issues'}
+                            data-kap-id="block-inspector-issues-tab"
+                        />
                     </Tabs>
                     {tab === 'logs' && (
                         <Box

--- a/src/panels/tools/BlockTypeTool.tsx
+++ b/src/panels/tools/BlockTypeTool.tsx
@@ -80,6 +80,7 @@ export const BlockTypeTool = (props: Props) => {
                                 boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.20)',
                             },
                         }}
+                        data-kap-id={`block-type-tool-${props.blockType.kind}`}
                     >
                         <Box
                             sx={{

--- a/src/panels/tools/PlannerResourcesList.tsx
+++ b/src/panels/tools/PlannerResourcesList.tsx
@@ -75,7 +75,12 @@ export const PlannerResourcesList = (props: Props) => {
                         textAlign: 'center',
                     }}
                 >
-                    <Button size="small" onClick={props.onShowMoreAssets} variant="outlined">
+                    <Button
+                        size="small"
+                        onClick={props.onShowMoreAssets}
+                        variant="outlined"
+                        data-kap-id="resources-open-blockhub"
+                    >
                         More assets
                     </Button>
                 </Box>

--- a/src/planner/components/ActionButtons.tsx
+++ b/src/planner/components/ActionButtons.tsx
@@ -16,6 +16,7 @@ const CircleButton = (props: any) => {
     // receives some sort of focus and is moved into view when closing the sidepanel it opens
     return (
         <div
+            data-kap-id={props['data-kap-id']}
             onClick={props.onClick}
             className={`svg-circle-button ${props.className}`}
             style={{ padding: 0, border: 0, background: 'none', ...(props.style || {}) }}
@@ -125,7 +126,8 @@ export const ActionButtons = (props: ActionButtonListProps) => {
                     {renderedActions.map((action: PlannerAction<any>, ix) => {
                         return (
                             <ActionButton
-                                key={ix}
+                                key={action.kapId || ix}
+                                kapId={action.kapId}
                                 action={action}
                                 show={props.show}
                                 transitionFn={() => transitionFn(ix)}
@@ -146,6 +148,10 @@ interface ActionButtonProps {
     actionContext: ActionContext;
     show: boolean;
     transitionFn: () => any;
+    /**
+     * Used to identify the button in tests and analytics
+     */
+    kapId?: string;
 }
 
 const ActionButton = (props: ActionButtonProps) => {
@@ -176,6 +182,7 @@ const ActionButton = (props: ActionButtonProps) => {
 
     return (
         <CircleButton
+            data-kap-id={props.kapId}
             label={label}
             icon={icon}
             className={containerClass}

--- a/src/planner/reference-resolver/ActionSelector.tsx
+++ b/src/planner/reference-resolver/ActionSelector.tsx
@@ -58,9 +58,28 @@ function toActionName(action: ActionType): string {
             return 'Select alternative type';
         case ActionType.REMOVE_BLOCK:
             return 'Remove block from plan';
+        default:
+            return '';
     }
+}
 
-    return '';
+function toActionId(action: ActionType): string {
+    switch (action) {
+        case ActionType.INSTALL:
+            return 'install';
+        case ActionType.SELECT_LOCAL_VERSION:
+            return 'select-local';
+        case ActionType.SELECT_ALTERNATIVE_VERSION:
+            return 'change-version';
+        case ActionType.SELECT_ALTERNATIVE_TYPE:
+            return 'change-type';
+        case ActionType.REMOVE_BLOCK:
+            return 'remove';
+        case ActionType.NONE:
+            return 'none';
+        default:
+            return '';
+    }
 }
 
 export const ActionSelector = (props: ActionSelectorProps) => {
@@ -118,6 +137,7 @@ export const ActionSelector = (props: ActionSelectorProps) => {
     return (
         <FormControl error={hasError}>
             <Select
+                data-kap-id="resolution-selector"
                 sx={{
                     width: '240px',
                 }}
@@ -129,10 +149,12 @@ export const ActionSelector = (props: ActionSelectorProps) => {
                     });
                 }}
             >
-                <MenuItem value={ActionType.NONE}>Select action...</MenuItem>
+                <MenuItem value={ActionType.NONE} data-kap-id="none">
+                    Select action...
+                </MenuItem>
                 {props.availableActions.map((action, ix) => {
                     return (
-                        <MenuItem key={ix} value={action}>
+                        <MenuItem key={ix} value={action} data-kap-id={`resolve-${toActionId(action)}`}>
                             {toActionName(action)}
                         </MenuItem>
                     );

--- a/src/planner/types.ts
+++ b/src/planner/types.ts
@@ -91,6 +91,7 @@ export interface PlannerAction<P extends unknown> {
     label: string | ((planner: PlannerContextData, info: ActionContext) => string);
     onClick(planner: PlannerContextData, context: ActionContext): void | Promise<void>;
     warningInspector?: boolean;
+    kapId?: string;
 }
 
 export interface BlockInfo {

--- a/stories/planner.stories.tsx
+++ b/stories/planner.stories.tsx
@@ -52,6 +52,7 @@ const InnerPlanEditor = forwardRef<HTMLDivElement, {}>((props: any, forwardedRef
                 icon: 'fa fa-search',
                 label: 'Inspect',
                 warningInspector: true,
+                kapId: 'inspect-block-instance',
             },
             {
                 enabled(): boolean {
@@ -63,6 +64,7 @@ const InnerPlanEditor = forwardRef<HTMLDivElement, {}>((props: any, forwardedRef
                 buttonStyle: ButtonStyle.PRIMARY,
                 icon: 'fa fa-play',
                 label: 'Test',
+                kapId: 'test-button',
             },
             {
                 enabled(context, { blockInstance }): boolean {
@@ -84,6 +86,7 @@ const InnerPlanEditor = forwardRef<HTMLDivElement, {}>((props: any, forwardedRef
                 buttonStyle: ButtonStyle.DANGER,
                 icon: 'fa fa-trash',
                 label: 'Delete',
+                kapId: 'delete-block-instance',
             },
             {
                 enabled(context, { blockInstance }): boolean {
@@ -103,6 +106,7 @@ const InnerPlanEditor = forwardRef<HTMLDivElement, {}>((props: any, forwardedRef
                 buttonStyle: ButtonStyle.SECONDARY,
                 icon: 'fa fa-pencil',
                 label: 'Edit',
+                kapId: 'edit-block-instance',
             },
             {
                 enabled(context, { blockInstance }): boolean {
@@ -139,6 +143,7 @@ const InnerPlanEditor = forwardRef<HTMLDivElement, {}>((props: any, forwardedRef
                 buttonStyle: ButtonStyle.SECONDARY,
                 icon: 'fa fa-pencil',
                 label: 'Edit',
+                kapId: 'edit-resource',
             },
             {
                 enabled(context, { blockInstance }): boolean {
@@ -160,6 +165,7 @@ const InnerPlanEditor = forwardRef<HTMLDivElement, {}>((props: any, forwardedRef
                 buttonStyle: ButtonStyle.DANGER,
                 icon: 'fa fa-trash',
                 label: 'Delete',
+                kapId: 'delete-resource',
             },
         ],
         connection: [
@@ -191,6 +197,7 @@ const InnerPlanEditor = forwardRef<HTMLDivElement, {}>((props: any, forwardedRef
                 buttonStyle: ButtonStyle.DANGER,
                 icon: 'fa fa-trash',
                 label: 'Delete',
+                kapId: 'delete-connection',
             },
         ],
     };

--- a/stories/styles.less
+++ b/stories/styles.less
@@ -101,3 +101,8 @@ body {
         display: inline-block;
     }
 }
+
+// poor mans devtools - highlight elements with kap-id
+// [data-kap-id] {
+//     box-shadow: 0 0 5px #f00 !important;
+// }


### PR DESCRIPTION
- fix: support string and date log timestamps
- feat: add support for data-kap-id and kapId props on planner components

We will have to add `kapId` to actions for the planner in the deployments and app.