### PR TITLE
feat: If all references can be resolved by installing show simpler UI

### DIFF
--- a/src/planner/reference-resolver/ProviderReferenceResolverItem.tsx
+++ b/src/planner/reference-resolver/ProviderReferenceResolverItem.tsx
@@ -6,7 +6,6 @@
 import { normalizeKapetaUri } from '@kapeta/nodejs-utils';
 import { ProviderBase, ResourceRole } from '@kapeta/ui-web-types';
 import { ReferenceType } from '../validation/PlanReferenceValidation';
-import { CoreTypes } from '@kapeta/ui-web-components';
 import { BlockTargetProvider, BlockTypeProvider, ResourceTypeProvider } from '@kapeta/ui-web-context';
 import { IconValue } from '@kapeta/schemas';
 import { TableCell, TableRow } from '@mui/material';
@@ -14,7 +13,13 @@ import { ArrowForward } from '@mui/icons-material';
 import { ActionSelector } from './ActionSelector';
 import React from 'react';
 import { ActionType, InnerItemProps } from './types';
-import { providerToSelectorMapper, toRef, useAvailableActions } from './helpers';
+import {
+    providerToSelectorMapper,
+    referenceTypeToKind,
+    referenceTypeToName,
+    toRef,
+    useAvailableActions,
+} from './helpers';
 import { createSubTitle, ReferenceTile } from './Tiles';
 import { ResolutionStateDisplay } from './ResolutionStateDisplay';
 
@@ -35,37 +40,29 @@ export const ProviderReferenceResolverItem = (props: InnerItemProps) => {
 
     let alternativeVersions: ProviderBase<any>[] = [];
     let availableTypes: ProviderBase<any>[] = [];
-    let typeName = '';
-    let kind = '';
+    let kind = referenceTypeToKind(props.missingReference.type);
+    let typeName = referenceTypeToName(props.missingReference.type);
 
     switch (props.missingReference.type) {
         case ReferenceType.TARGET:
-            typeName = 'Language target';
-            kind = CoreTypes.LANGUAGE_TARGET;
             alternativeVersions = BlockTargetProvider.getVersionsFor(props.refUri.fullName).map((version) => {
                 return BlockTargetProvider.get(toRef(props.refUri.fullName, version), blockAsset.content.kind);
             });
             availableTypes = BlockTargetProvider.list(blockAsset.content.kind);
             break;
         case ReferenceType.PROVIDER:
-            typeName = 'Provider resource';
-            kind = CoreTypes.PROVIDER_INTERNAL;
             alternativeVersions = ResourceTypeProvider.getVersionsFor(props.refUri.fullName).map((version) => {
                 return ResourceTypeProvider.get(toRef(props.refUri.fullName, version));
             });
             availableTypes = ResourceTypeProvider.list().filter((t) => t.role === ResourceRole.PROVIDES);
             break;
         case ReferenceType.CONSUMER:
-            typeName = 'Consumer resource';
-            kind = CoreTypes.PROVIDER_INTERNAL;
             alternativeVersions = ResourceTypeProvider.getVersionsFor(props.refUri.fullName).map((version) => {
                 return ResourceTypeProvider.get(toRef(props.refUri.fullName, version));
             });
             availableTypes = ResourceTypeProvider.list().filter((t) => t.role === ResourceRole.CONSUMES);
             break;
         case ReferenceType.KIND:
-            typeName = 'Block kind';
-            kind = CoreTypes.BLOCK_TYPE;
             alternativeVersions = BlockTypeProvider.getVersionsFor(props.refUri.fullName).map((version) => {
                 return BlockTypeProvider.get(toRef(props.refUri.fullName, version));
             });

--- a/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
+++ b/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
@@ -35,6 +35,10 @@ export const ReferenceResolutionHandler = (props: Omit<ReferenceResolverModalPro
         return resolutions?.some((r) => r.resolution?.action === ActionType.NONE_AVAILABLE) || false;
     }, [resolutions]);
 
+    const allInstallable = useMemo(() => {
+        return resolutions?.every((r) => r.resolution?.action === ActionType.INSTALL) || false;
+    }, [resolutions]);
+
     useEffect(() => {
         if (props.open || props.inline) {
             // Reset state whenever the modal is opened
@@ -77,7 +81,7 @@ export const ReferenceResolutionHandler = (props: Omit<ReferenceResolverModalPro
                 }
             }}
         >
-            Apply changes
+            {allInstallable ? 'Install now' : 'Apply changes'}
         </KapButton>
     ) : null;
 

--- a/src/planner/reference-resolver/ReferenceResolverItem.tsx
+++ b/src/planner/reference-resolver/ReferenceResolverItem.tsx
@@ -39,12 +39,14 @@ export const ReferenceResolverItem = (props: ItemProps) => {
         );
     }
 
+    const canInstallValue = Boolean(canInstall.value);
+
     if (props.missingReference.type === ReferenceType.BLOCK) {
         return (
             <BlockReferenceResolverItem
                 {...props}
                 readOnlyBlock={readOnlyBlock}
-                canInstall={Boolean(canInstall.value)}
+                canInstall={canInstallValue}
                 blockUri={blockUri}
                 refUri={refUri}
             />
@@ -55,7 +57,7 @@ export const ReferenceResolverItem = (props: ItemProps) => {
         <ProviderReferenceResolverItem
             {...props}
             readOnlyBlock={readOnlyBlock}
-            canInstall={Boolean(canInstall.value)}
+            canInstall={canInstallValue}
             blockUri={blockUri}
             refUri={refUri}
         />

--- a/src/planner/reference-resolver/ResolutionStateDisplay.tsx
+++ b/src/planner/reference-resolver/ResolutionStateDisplay.tsx
@@ -37,6 +37,7 @@ export const ResolutionStateDisplay = (props: Props) => {
 
     return (
         <Stack
+            className={'resolution-state'}
             sx={{
                 color,
             }}

--- a/src/planner/reference-resolver/ResolutionStateDisplay.tsx
+++ b/src/planner/reference-resolver/ResolutionStateDisplay.tsx
@@ -21,7 +21,7 @@ export const ResolutionStateDisplay = (props: Props) => {
         case ResolutionStateType.ACTIVE:
             message = 'Applying...';
             color = 'info.main';
-            icon = <CircularProgress color="inherit" />;
+            icon = <CircularProgress size={20} color="inherit" />;
             break;
         case ResolutionStateType.DONE:
             message = 'Done';

--- a/src/planner/reference-resolver/Tiles.tsx
+++ b/src/planner/reference-resolver/Tiles.tsx
@@ -22,6 +22,7 @@ export function createSubTitle(hasVersionAlternatives: boolean, refUri: KapetaUR
 export const Tile = (props: PropsWithChildren & { sx?: SxProps }) => {
     return (
         <Stack
+            className={'tile'}
             direction={'row'}
             gap={1}
             alignItems={'center'}

--- a/src/planner/reference-resolver/helpers.ts
+++ b/src/planner/reference-resolver/helpers.ts
@@ -5,10 +5,11 @@
 
 import { useEffect, useMemo } from 'react';
 import { ReferenceType } from '../validation/PlanReferenceValidation';
-import { ProviderBase } from '@kapeta/ui-web-types';
-import { AssetVersionSelectorEntry } from '@kapeta/ui-web-components';
+import { ProviderBase, ResourceRole } from '@kapeta/ui-web-types';
+import { AssetVersionSelectorEntry, CoreTypes } from '@kapeta/ui-web-components';
 import { normalizeKapetaUri } from '@kapeta/nodejs-utils';
 import { ActionType, InnerItemProps } from './types';
+import { BlockTargetProvider, BlockTypeProvider, ResourceTypeProvider } from '@kapeta/ui-web-context';
 
 export function shortenPathName(path: string) {
     const parts = path.split(/[\\/]/g);
@@ -74,4 +75,34 @@ export const providerToSelectorMapper = (provider: ProviderBase<any>): AssetVers
         icon: provider.icon,
         title: provider.title,
     };
+};
+
+export const referenceTypeToKind = (type: ReferenceType) => {
+    switch (type) {
+        case ReferenceType.TARGET:
+            return CoreTypes.LANGUAGE_TARGET;
+        case ReferenceType.PROVIDER:
+            return CoreTypes.PROVIDER_INTERNAL;
+        case ReferenceType.CONSUMER:
+            return CoreTypes.PROVIDER_INTERNAL;
+        case ReferenceType.KIND:
+            return CoreTypes.BLOCK_TYPE;
+    }
+
+    return '';
+};
+
+export const referenceTypeToName = (type: ReferenceType) => {
+    switch (type) {
+        case ReferenceType.TARGET:
+            return 'Language target';
+        case ReferenceType.PROVIDER:
+            return 'Provider resource';
+        case ReferenceType.CONSUMER:
+            return 'Consumer resource';
+        case ReferenceType.KIND:
+            return 'Block Type';
+        case ReferenceType.BLOCK:
+            return 'Block';
+    }
 };

--- a/stories/reference-resolver.stories.tsx
+++ b/stories/reference-resolver.stories.tsx
@@ -72,7 +72,7 @@ const assetCanBeInstalled = (ref: string) => {
 };
 const installAsset = (ref: string) => {
     console.log('INSTALL', ref);
-    return Promise.resolve();
+    return new Promise<void>((resolve) => setTimeout(() => resolve(), 3000 * Math.random()));
 };
 
 const onChange = (resolution: MissingReferenceResolution[], valid: boolean) => {
@@ -158,6 +158,28 @@ export const WriteableContextModal = () => {
                     onClose={() => {}}
                     blockAssets={blocks.value!.map(fromAsset)}
                     assetCanBeInstalled={assetCanBeInstalled}
+                    installAsset={installAsset}
+                    readOnly={false}
+                    missingReferences={createMissingReferences('local')}
+                    selectAssetFromDisk={selectAssetFromDisk}
+                />
+            )}
+        </>
+    );
+};
+
+export const WriteableContextAllInstallModal = () => {
+    const blocks = useAsync(() => BlockService.list());
+
+    return (
+        <>
+            {!blocks.loading && (
+                <ReferenceResolutionHandler
+                    plan={InvalidPlannerData}
+                    open={true}
+                    onClose={() => {}}
+                    blockAssets={blocks.value!.map(fromAsset)}
+                    assetCanBeInstalled={(ref) => Promise.resolve(true)}
                     installAsset={installAsset}
                     readOnly={false}
                     missingReferences={createMissingReferences('local')}


### PR DESCRIPTION
If it's just missing installable assets we do not show it as an error situation but rather part of preparing a new plan

![image](https://github.com/kapetacom/ui-web-plan-editor/assets/441655/478f5772-e2d3-4f13-86c0-86ccf4a7ba7d)
![image](https://github.com/kapetacom/ui-web-plan-editor/assets/441655/e715c04b-27db-4a1e-9391-7865f1f477c8)

Versus the "normal" resolving UI: 

![image](https://github.com/kapetacom/ui-web-plan-editor/assets/441655/5baae200-c460-4c3b-b1dd-e13ba0e95eb2)
