### PR TITLE
fix: Disable user selection while resizing

### DIFF
--- a/src/panels/PlannerSidebar.tsx
+++ b/src/panels/PlannerSidebar.tsx
@@ -36,7 +36,7 @@ const sizeToWidth = {
 export const PlannerSidebar = (props: PlannerSidebarProps) => {
     const { title, size = 'medium', minWidth = sizeToWidth.small, maxWidth, children, ...drawerProps } = props;
 
-    const { onResize, ...resizeWidths } = useResize({
+    const { onResize, isResizing, ...resizeWidths } = useResize({
         direction: 'left',
         initialWidth: sizeToWidth[size],
         minWidth,
@@ -52,6 +52,7 @@ export const PlannerSidebar = (props: PlannerSidebarProps) => {
                     p: 4,
                     boxSizing: 'border-box',
                     overflow: 'visible',
+                    ...(isResizing ? { userSelect: 'none' } : {}),
                     ...resizeWidths,
                 },
             }}

--- a/src/panels/useResize.tsx
+++ b/src/panels/useResize.tsx
@@ -79,6 +79,7 @@ export const useResize = (props: UseResizeProps) => {
 
     return {
         onResize,
+        isResizing,
         width: `min(${width}px, 100%)`,
         minWidth: `${minWidth}px`,
     };


### PR DESCRIPTION
It looks like we in Safari needs to disable `user-select` while the user is resizing to avoid the content of the sidebar to be selected.