### PR TITLE
fix: Enable custom title in PlannerSidebar

### DIFF
--- a/src/panels/PlannerSidebar.tsx
+++ b/src/panels/PlannerSidebar.tsx
@@ -8,7 +8,7 @@ import { DrawerProps, Drawer, Typography, Divider, Box, Stack, IconButton } from
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { VerticalResizeHandle, useResize } from './useResize';
 
-interface PlannerSidebarProps extends PropsWithChildren, Omit<DrawerProps, 'children' | 'anchor' | 'title'> {
+export interface PlannerSidebarProps extends PropsWithChildren, Omit<DrawerProps, 'children' | 'anchor' | 'title'> {
     /**
      * The title of the planner sidebar
      */

--- a/src/panels/PlannerSidebar.tsx
+++ b/src/panels/PlannerSidebar.tsx
@@ -3,16 +3,16 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactNode } from 'react';
 import { DrawerProps, Drawer, Typography, Divider, Box, Stack, IconButton } from '@mui/material';
-import { CloseRounded } from '@mui/icons-material';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { VerticalResizeHandle, useResize } from './useResize';
 
-interface PlannerSidebarProps extends PropsWithChildren, Omit<DrawerProps, 'children' | 'anchor'> {
+interface PlannerSidebarProps extends PropsWithChildren, Omit<DrawerProps, 'children' | 'anchor' | 'title'> {
     /**
      * The title of the planner sidebar
      */
-    title: string;
+    title: ReactNode;
     /**
      * The size of the planner sidebar. Default is 'medium' (600px).
      */
@@ -76,9 +76,13 @@ export const PlannerSidebar = (props: PlannerSidebarProps) => {
                             fontSize: '22px',
                         }}
                     >
-                        <Typography fontSize={'inherit'} variant={'h3'}>
-                            {title}
-                        </Typography>
+                        {typeof title === 'string' ? (
+                            <Typography fontSize={'inherit'} variant={'h3'}>
+                                {title}
+                            </Typography>
+                        ) : (
+                            title
+                        )}
                         <IconButton
                             sx={{
                                 fontSize: 'inherit',
@@ -88,11 +92,12 @@ export const PlannerSidebar = (props: PlannerSidebarProps) => {
                                     drawerProps.onClose(evt, 'escapeKeyDown');
                                 }
                             }}
+                            size="medium"
                         >
-                            <CloseRounded />
+                            <CloseRoundedIcon fontSize="inherit" />
                         </IconButton>
                     </Stack>
-                    <Divider />
+                    <Divider sx={{ mt: 0.5 }} />
                 </Box>
                 <Box
                     flex={1}

--- a/stories/planner.stories.tsx
+++ b/stories/planner.stories.tsx
@@ -16,7 +16,7 @@ import { useAsync } from 'react-use';
 import { ItemType, ResourceRole, SchemaKind } from '@kapeta/ui-web-types';
 import { parseKapetaUri } from '@kapeta/nodejs-utils';
 import { ItemEditorPanel } from './helpers/ItemEditorPanel';
-import { EditItemInfo, PlannerMode } from '../src';
+import { EditItemInfo, PlannerMode, PlannerSidebar } from '../src';
 import { InstanceStatus } from '@kapeta/ui-web-context';
 
 import { BlockDefinition, BlockInstance, Resource } from '@kapeta/schemas';
@@ -26,8 +26,9 @@ import { PlannerResourcesList } from '../src/panels/tools/PlannerResourcesList';
 
 import { useConfirmDelete } from '@kapeta/ui-web-components';
 import { PlannerDrawer } from '../src/panels/PlannerDrawer';
-import { Tab, Tabs } from '@mui/material';
+import { Box, IconButton, Tab, Tabs, Typography } from '@mui/material';
 import { PublicUrlList } from '../src/panels/tools/PublicUrlList';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 
 import './styles.less';
 
@@ -420,5 +421,41 @@ export const CustomRenderer = () => {
         <plannerRenderer.Provider outlets={outlets}>
             <PlannerLoader plannerMode={PlannerMode.EDIT} instanceStatus={InstanceStatus.STARTING} />
         </plannerRenderer.Provider>
+    );
+};
+
+export const PlannerSidebarWithStringTitle = () => {
+    const [open, setOpen] = React.useState(true);
+    return (
+        <PlannerSidebar open={open} title="Sidebar title" onClose={() => setOpen(false)}>
+            Sidebar content
+        </PlannerSidebar>
+    );
+};
+
+export const PlannerSidebarWithCustomTitle = () => {
+    const [open, setOpen] = React.useState(true);
+    return (
+        <PlannerSidebar
+            open={open}
+            title={
+                <Box
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        width: '100%',
+                    }}
+                >
+                    <Typography variant="h6">Sidebar title</Typography>
+                    <IconButton size="medium">
+                        <SettingsOutlinedIcon fontSize="inherit" />
+                    </IconButton>
+                </Box>
+            }
+            onClose={() => setOpen(false)}
+        >
+            Sidebar content
+        </PlannerSidebar>
     );
 };


### PR DESCRIPTION
Make is possible to pass in a ReactNode as `title` to PlannerSidebar


- With custom title
  <img width="636" alt="image" src="https://github.com/kapetacom/ui-web-plan-editor/assets/1045799/026688bf-752f-41f9-92ed-24f71fede451">
- With string title
  <img width="646" alt="image" src="https://github.com/kapetacom/ui-web-plan-editor/assets/1045799/d65d6336-32c2-418b-95c4-727603ed6fe0">
