### PR TITLE
feat: use simplified gateway status for gatewaycards

### DIFF
--- a/src/components/GatewayCard.tsx
+++ b/src/components/GatewayCard.tsx
@@ -17,7 +17,6 @@ import {
     Typography,
     useTheme,
 } from '@mui/material';
-import { InstanceStatus } from '@kapeta/ui-web-context';
 import { Language, Link, LinkOff, MoreVert } from '@mui/icons-material';
 import { Tooltip as KapTooltip } from '@kapeta/ui-web-components';
 
@@ -26,8 +25,6 @@ interface GatewayCardProps {
     fallbackText?: string;
 
     loading?: boolean;
-    status?: InstanceStatus;
-
     primary?: {
         url: string | null;
         status?: 'ok' | 'loading' | 'error';
@@ -134,40 +131,13 @@ export const GatewayCard = (props: GatewayCardProps) => {
 
     // Status color
     const { palette } = useTheme();
-    const statusColorMap: Record<InstanceStatus, string> = {
-        [InstanceStatus.STARTING]: palette.success.main,
-        [InstanceStatus.READY]: palette.success.main,
-        [InstanceStatus.STOPPING]: palette.success.main,
-        [InstanceStatus.STOPPED]: '#0000003b',
-        [InstanceStatus.FAILED]: palette.error.main,
-        [InstanceStatus.UNHEALTHY]: palette.warning.main,
-        [InstanceStatus.BUSY]: palette.warning.main,
-    };
-    const statusColor = statusColorMap[props.status || InstanceStatus.STOPPED];
-
-    // Status text
-    const titleMapping: Record<InstanceStatus, string> = {
-        [InstanceStatus.STARTING]: 'Block is starting',
-        [InstanceStatus.READY]: 'Block is ready',
-        [InstanceStatus.UNHEALTHY]: 'Block is unhealthy. View logs to see more information.',
-        [InstanceStatus.FAILED]: 'Block failed to start or crashed. View logs to see more information.',
-        [InstanceStatus.STOPPED]: 'Block has stopped',
-        [InstanceStatus.STOPPING]: 'Block is stopping',
-        [InstanceStatus.BUSY]: 'Block is unresponsive',
-    };
-    let statusText: string = '';
-    if (props.loading) {
-        statusText = 'Loading...';
-    } else {
-        statusText = titleMapping[props.status || InstanceStatus.STOPPED];
-    }
-
-    // Status pulsate
-    const shouldPulsate =
-        props.loading ||
-        props.status === InstanceStatus.STARTING ||
-        props.status === InstanceStatus.STOPPING ||
-        props.status === InstanceStatus.UNHEALTHY;
+    const statusColor = {
+        ok: palette.success.main,
+        loading: '#0000003b',
+        error: palette.error.main,
+    }[entry?.status || 'loading'];
+    const statusText: string = entry?.message || (props.loading && 'Loading') || '';
+    const shouldPulsate = props.loading || entry?.status === 'loading';
 
     const card = (
         <Stack

--- a/stories/gateway-card.stories.tsx
+++ b/stories/gateway-card.stories.tsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import { GatewayCard } from '../src/components/GatewayCard';
-import { InstanceStatus } from '@kapeta/ui-web-context';
 
 export default {
     title: 'Gateway Cards',
@@ -33,7 +32,6 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
         {
             label: 'Editor mode',
             props: {
-                status: InstanceStatus.READY,
                 fallbackText: 'Open in browser',
                 primary: undefined,
                 fallback: {
@@ -68,20 +66,17 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
     ],
     [
         {
-            label: 'Block statuses',
-            props: { title: 'Starting', status: InstanceStatus.STARTING },
+            label: 'URL statuses',
+            props: { title: 'Loading', primary: { status: 'loading', url: 'https://example.com' } },
         },
         {
-            props: { title: 'Ready', status: InstanceStatus.READY },
+            props: {
+                title: 'Error',
+                primary: { status: 'error', url: 'https://example.com', message: 'An error occurred' },
+            },
         },
         {
-            props: { title: 'Unhealthy', status: InstanceStatus.UNHEALTHY },
-        },
-        {
-            props: { title: 'Stopped', status: InstanceStatus.STOPPED },
-        },
-        {
-            props: { title: 'Failed', status: InstanceStatus.FAILED },
+            props: { title: 'Ok', primary: { status: 'ok', url: 'https://example.com', message: 'URL is ready' } },
         },
     ],
 
@@ -89,7 +84,6 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
         {
             label: 'Custom URL',
             props: {
-                status: InstanceStatus.READY,
                 primary: {
                     url: 'https://example.com',
                     status: 'loading',
@@ -102,7 +96,6 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
         },
         {
             props: {
-                status: InstanceStatus.READY,
                 primary: {
                     url: 'https://example.com',
                     status: 'ok',
@@ -115,7 +108,6 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
         },
         {
             props: {
-                status: InstanceStatus.READY,
                 primary: {
                     url: 'https://example.com',
                     status: 'error',
@@ -139,7 +131,6 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
         {
             label: 'Fallback only',
             props: {
-                status: InstanceStatus.READY,
                 fallback: {
                     url: 'https://kap-abc.kapeta.dev',
                     status: 'loading',
@@ -148,7 +139,6 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
         },
         {
             props: {
-                status: InstanceStatus.READY,
                 fallback: {
                     url: 'https://kap-abc.kapeta.dev',
                     status: 'ok',
@@ -157,7 +147,6 @@ const groups: { label?: string; props: Partial<React.ComponentProps<typeof Gatew
         },
         {
             props: {
-                status: InstanceStatus.READY,
                 fallback: {
                     url: 'https://kap-abc.kapeta.dev',
                     status: 'error',


### PR DESCRIPTION
Gateway cards are no longer reflecting instanceStatuses, so we can simplify the status logic a bit.

<img width="1075" alt="Screenshot 2023-12-05 at 07 48 34" src="https://github.com/kapetacom/ui-web-plan-editor/assets/296057/41b4398b-b283-47e3-8864-94ec269ed6e2">
