### PR TITLE
fix: foreignObjects sometimes have a hidden overflow

### DIFF
--- a/src/planner/Planner.less
+++ b/src/planner/Planner.less
@@ -203,7 +203,9 @@
 .planner-area-canvas,
 .planner-block-node-container,
 .planner-canvas svg,
-.planner-area-canvas svg {
+.planner-canvas foreignObject,
+.planner-area-canvas svg,
+.planner-area-canvas foreignObject {
     overflow: visible;
 }
 


### PR DESCRIPTION
![image](https://github.com/kapetacom/ui-web-plan-editor/assets/441655/8355cdb5-8c7b-442d-82cd-3f9cb8c2dcdd)
