### PR TITLE
fix: prevent canvas from always overflowing

### DIFF
--- a/src/planner/PlannerCanvas.tsx
+++ b/src/planner/PlannerCanvas.tsx
@@ -23,8 +23,6 @@ import { parseKapetaUri } from '@kapeta/nodejs-utils';
 import { adjustBlockEdges } from './components/PlannerBlockNode';
 import { ReferenceValidationError, usePlanValidation } from './validation/PlanReferenceValidation';
 
-const PLAN_PADDING = 50;
-
 const toBlockPoint = (mousePoint: Point, zoom: number): Point => {
     return {
         y: mousePoint.y / zoom,
@@ -174,8 +172,8 @@ export const PlannerCanvas: React.FC<Props> = (props) => {
                                 style={{
                                     transformOrigin: 'top left',
                                     transform: `scale(${planner.zoom})`,
-                                    width: PLAN_PADDING + canvasSize.width,
-                                    height: PLAN_PADDING + canvasSize.height,
+                                    width: canvasSize.width,
+                                    height: canvasSize.height,
                                 }}
                             >
                                 {props.children}


### PR DESCRIPTION
Noticed this in the context of the AI plan view.

The canvas size calculation already has padding logic. Removing this padding
should only affect the overflow behavior of the scroll parent.

- Before: https://63e4c5bbea99978253f1f800-xacgmhgcec.chromatic.com/?path=/story/planner--view-only
- After: https://63e4c5bbea99978253f1f800-hydnmjapxl.chromatic.com/?path=/story/planner--view-only
