### PR TITLE
fix: handle local resolutions with different name than original [KAP-2187]

### DIFF
--- a/src/planner/reference-resolver/BlockReferenceResolverItem.tsx
+++ b/src/planner/reference-resolver/BlockReferenceResolverItem.tsx
@@ -10,7 +10,7 @@ import { ArrowForward } from '@mui/icons-material';
 import { ActionSelector } from './ActionSelector';
 import React from 'react';
 import { createSubTitle, ReferenceTile } from './Tiles';
-import { ActionType, InnerItemProps } from './types';
+import { ActionType, InnerItemProps, NO_RESOLUTION } from './types';
 import { useAvailableActions } from './helpers';
 import { ResolutionStateDisplay } from './ResolutionStateDisplay';
 
@@ -47,7 +47,10 @@ export const BlockReferenceResolverItem = (props: InnerItemProps) => {
             </TableCell>
             <TableCell>
                 {props.resolutionState ? (
-                    <ResolutionStateDisplay resolutionState={props.resolutionState} />
+                    <ResolutionStateDisplay
+                        resolutionState={props.resolutionState}
+                        onRetry={() => props.onResolution(NO_RESOLUTION)}
+                    />
                 ) : (
                     <ActionSelector
                         resolution={props.resolution}

--- a/src/planner/reference-resolver/ProviderReferenceResolverItem.tsx
+++ b/src/planner/reference-resolver/ProviderReferenceResolverItem.tsx
@@ -12,7 +12,7 @@ import { TableCell, TableRow } from '@mui/material';
 import { ArrowForward } from '@mui/icons-material';
 import { ActionSelector } from './ActionSelector';
 import React from 'react';
-import { ActionType, InnerItemProps } from './types';
+import { ActionType, InnerItemProps, NO_RESOLUTION } from './types';
 import {
     providerToSelectorMapper,
     referenceTypeToKind,
@@ -68,6 +68,11 @@ export const ProviderReferenceResolverItem = (props: InnerItemProps) => {
             });
             availableTypes = BlockTypeProvider.list();
             break;
+        case ReferenceType.BLOCK:
+            throw new Error('Wrong resolver for type block');
+        default:
+            props.missingReference.type satisfies never;
+            break;
     }
 
     const availableActions: ActionType[] = useAvailableActions(
@@ -104,7 +109,10 @@ export const ProviderReferenceResolverItem = (props: InnerItemProps) => {
             </TableCell>
             <TableCell>
                 {props.resolutionState ? (
-                    <ResolutionStateDisplay resolutionState={props.resolutionState} />
+                    <ResolutionStateDisplay
+                        resolutionState={props.resolutionState}
+                        onRetry={() => props.onResolution(NO_RESOLUTION)}
+                    />
                 ) : (
                     <ActionSelector
                         resolution={props.resolution}

--- a/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
+++ b/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
@@ -12,6 +12,7 @@ import {
     PlanResolutionResult,
     PlanResolutionTransformer,
     ResolutionState,
+    ResolutionStateType,
 } from '../validation/PlanResolutionTransformer';
 
 interface ReferenceResolverModalProps extends Omit<ReferenceResolverProps, 'onChange'> {
@@ -98,6 +99,10 @@ export const ReferenceResolutionHandler = (props: Omit<ReferenceResolverModalPro
             onDelayingCheck={(delaying) => setDelaying(delaying)}
             onChange={(resolutions, valid) => {
                 setResolutions(resolutions);
+                setResolutionStates((states) =>
+                    // Clear state for resolutions that are no longer present
+                    states.filter((s, ix) => resolutions[ix]?.resolution?.action !== ActionType.NONE)
+                );
                 setValid(valid);
                 if (valid && showErrors) {
                     setShowErrors(false);

--- a/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
+++ b/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
@@ -19,7 +19,12 @@ interface ReferenceResolverModalProps extends Omit<ReferenceResolverProps, 'onCh
     onClose?: () => void;
     onResolved?: (result: PlanResolutionResult) => void | Promise<void>;
     installAsset?: (ref: string) => Promise<void>;
-    importAsset?: (ref: string) => Promise<void>;
+    /**
+     *
+     * @param ref Asset path to import
+     * @returns The new asset ref as a string or null if the import failed
+     */
+    importAsset?: (ref: string) => Promise<string | null>;
     inline?: boolean;
 }
 

--- a/src/planner/reference-resolver/ResolutionStateDisplay.tsx
+++ b/src/planner/reference-resolver/ResolutionStateDisplay.tsx
@@ -5,17 +5,19 @@
 
 import { ResolutionState, ResolutionStateType } from '../validation/PlanResolutionTransformer';
 import React from 'react';
-import { Box, CircularProgress, Stack, Typography } from '@mui/material';
+import { Box, Button, CircularProgress, Stack, Typography } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 interface Props {
     resolutionState: ResolutionState;
+    onRetry?: () => void;
 }
 
 export const ResolutionStateDisplay = (props: Props) => {
     let message = '';
     let icon: any = null;
     let color = '';
+    let showRetry = false;
     switch (props.resolutionState.state) {
         case ResolutionStateType.IDLE:
         case ResolutionStateType.ACTIVE:
@@ -32,6 +34,10 @@ export const ResolutionStateDisplay = (props: Props) => {
             message = `Failed: ${props.resolutionState.error}`;
             color = 'error.main';
             icon = <ErrorOutlineIcon />;
+            showRetry = true;
+            break;
+        default:
+            props.resolutionState.state satisfies never;
             break;
     }
 
@@ -47,6 +53,11 @@ export const ResolutionStateDisplay = (props: Props) => {
         >
             {icon}
             <Typography color={'inherit'}>{message}</Typography>
+            {props.onRetry && showRetry && (
+                <Button variant="text" onClick={props.onRetry}>
+                    Reset
+                </Button>
+            )}
         </Stack>
     );
 };

--- a/src/planner/reference-resolver/types.ts
+++ b/src/planner/reference-resolver/types.ts
@@ -29,6 +29,7 @@ export interface Resolution {
 
 export const NO_RESOLUTION: Resolution = {
     action: ActionType.NONE,
+    value: undefined,
 };
 
 export interface MissingReferenceResolution extends MissingReference {

--- a/src/planner/validation/PlanResolutionTransformer.ts
+++ b/src/planner/validation/PlanResolutionTransformer.ts
@@ -24,7 +24,7 @@ export type PlanResolutionResult = {
 
 export type PlanResolutionOptions = {
     installAsset?: (ref: string) => Promise<void>;
-    importAsset?: (ref: string) => Promise<void>;
+    importAsset?: (ref: string) => Promise<string | null>;
 };
 
 export enum ResolutionStateType {
@@ -45,7 +45,7 @@ export class PlanResolutionTransformer extends EventEmitter {
     private readonly options?: PlanResolutionOptions;
     private readonly changedBlocks: AssetInfo<BlockDefinition>[] = [];
     private resolutionStates: ResolutionState[] = [];
-    private solutions: { [key: string]: Promise<void> } = {};
+    private solutions: { [key: string]: Promise<string | null> } = {};
     private changedPlan?: Plan;
 
     constructor(
@@ -109,11 +109,18 @@ export class PlanResolutionTransformer extends EventEmitter {
 
             case ActionType.SELECT_LOCAL_VERSION:
                 // Import this from the path provided
-                return this.importLocalVersion(referenceResolution.resolution.value!);
+                const importedRef = await this.importLocalVersion(referenceResolution.resolution.value!);
+                if (!importedRef) {
+                    throw new Error('No asset imported from path ' + referenceResolution.resolution.value);
+                }
+                // In case it's not the exact same reference, replace it in the plan:
+                return this.replaceReference(referenceResolution, importedRef);
 
             case ActionType.REMOVE_BLOCK:
                 // Remove block from plan
                 return this.removeInstance(referenceResolution.instanceId!);
+            default:
+                throw new Error('Unknown action type');
         }
     }
 
@@ -146,7 +153,10 @@ export class PlanResolutionTransformer extends EventEmitter {
             throw new Error('Instance not found');
         }
 
-        if (referenceResolution.type === ReferenceType.BLOCK) {
+        if (
+            referenceResolution.type === ReferenceType.BLOCK ||
+            (referenceResolution.type === ReferenceType.TARGET && instance.block.ref !== referenceResolution.ref)
+        ) {
             instance.block.ref = value;
             this.setChangedPlan(tempPlan);
             return;
@@ -234,7 +244,7 @@ export class PlanResolutionTransformer extends EventEmitter {
 
     private async importLocalVersion(kapetaYmlPath: string) {
         if (!this.solutions[kapetaYmlPath]) {
-            this.solutions[kapetaYmlPath] = this.options?.importAsset?.(kapetaYmlPath) ?? Promise.resolve();
+            this.solutions[kapetaYmlPath] = this.options?.importAsset?.(kapetaYmlPath) ?? Promise.resolve(null);
         }
 
         return this.solutions[kapetaYmlPath];
@@ -242,7 +252,7 @@ export class PlanResolutionTransformer extends EventEmitter {
 
     private async install(ref: string) {
         if (!this.solutions[ref]) {
-            this.solutions[ref] = this.options?.installAsset?.(ref) ?? Promise.resolve();
+            this.solutions[ref] = this.options?.installAsset?.(ref).then(() => '') ?? Promise.resolve(null);
         }
         return this.solutions[ref];
     }

--- a/src/planner/validation/PlanResolutionTransformer.ts
+++ b/src/planner/validation/PlanResolutionTransformer.ts
@@ -153,10 +153,7 @@ export class PlanResolutionTransformer extends EventEmitter {
             throw new Error('Instance not found');
         }
 
-        if (
-            referenceResolution.type === ReferenceType.BLOCK ||
-            (referenceResolution.type === ReferenceType.TARGET && instance.block.ref !== referenceResolution.ref)
-        ) {
+        if (referenceResolution.type === ReferenceType.BLOCK) {
             instance.block.ref = value;
             this.setChangedPlan(tempPlan);
             return;

--- a/stories/previews.stories.tsx
+++ b/stories/previews.stories.tsx
@@ -242,9 +242,8 @@ export const ThumbnailPlan = () => {
     );
 };
 
-function delayedPromise<T>(delay: number, value?: () => T): () => Promise<T> {
-    // @ts-ignore
-    return () => new Promise<T>((resolve) => setTimeout(() => resolve(value ? value() : null), Math.random() * delay));
+function delayedPromise<T>(delay: number, value?: T): Promise<T> {
+    return new Promise<T>((resolve) => setTimeout(resolve, Math.random() * delay, value));
 }
 
 export const ThumbnailPlanMissingAssets = () => {
@@ -265,11 +264,13 @@ export const ThumbnailPlanMissingAssets = () => {
     }
 
     const installerService = {
-        install: delayedPromise<void>(10000),
-        import: delayedPromise<void>(10000),
-        get: delayedPromise<AssetInstallStatus>(1000, () =>
-            Math.random() > 0.5 ? AssetInstallStatus.INSTALLED : AssetInstallStatus.NOT_INSTALLED
-        ),
+        install: (ref: string) => delayedPromise<void>(10000),
+        import: (_path: string) => delayedPromise<string>(10000, 'kapeta/something:local'),
+        get: () =>
+            delayedPromise<AssetInstallStatus>(
+                1000,
+                Math.random() > 0.5 ? AssetInstallStatus.INSTALLED : AssetInstallStatus.NOT_INSTALLED
+            ),
     };
 
     return (
@@ -279,8 +280,8 @@ export const ThumbnailPlanMissingAssets = () => {
                 plan={plan}
                 blockAssets={blockAssets}
                 assetCanBeInstalled={async () => (await installerService.get()) !== AssetInstallStatus.INSTALLED}
-                installAsset={() => installerService.install()}
-                importAsset={() => installerService.import()}
+                installAsset={(ref) => installerService.install(ref)}
+                importAsset={(path) => installerService.import(path)}
                 readOnly={false}
                 missingReferences={missingReferences}
                 onClose={() => setOpen(false)}
@@ -384,7 +385,7 @@ export const ThumbnailBlock = () => {
                 onClick={() => {}}
                 installerService={{
                     uninstall: () => Promise.resolve(),
-                    install: () => Promise.resolve(),
+                    install: (ref) => Promise.resolve(),
                     get: () => Promise.resolve(AssetInstallStatus.INSTALLED),
                 }}
                 loadPlanContext={() => {

--- a/stories/reference-resolver.stories.tsx
+++ b/stories/reference-resolver.stories.tsx
@@ -72,7 +72,7 @@ const assetCanBeInstalled = (ref: string) => {
 };
 const installAsset = (ref: string) => {
     console.log('INSTALL', ref);
-    return new Promise<void>((resolve) => setTimeout(() => resolve(), 3000 * Math.random()));
+    return new Promise<void>((resolve) => setTimeout(resolve, 3000 * Math.random()));
 };
 
 const onChange = (resolution: MissingReferenceResolution[], valid: boolean) => {
@@ -176,7 +176,7 @@ export const WriteableContextAllInstallModal = () => {
             {!blocks.loading && (
                 <ReferenceResolutionHandler
                     plan={InvalidPlannerData}
-                    open={true}
+                    open
                     onClose={() => {}}
                     blockAssets={blocks.value!.map(fromAsset)}
                     assetCanBeInstalled={(ref) => Promise.resolve(true)}
@@ -184,6 +184,7 @@ export const WriteableContextAllInstallModal = () => {
                     readOnly={false}
                     missingReferences={createMissingReferences('local')}
                     selectAssetFromDisk={selectAssetFromDisk}
+                    importAsset={() => Promise.resolve('kapeta/other:local')}
                 />
             )}
         </>
@@ -202,18 +203,21 @@ export const MissingLocal = () => {
                     assetCanBeInstalled={assetCanBeInstalled}
                     readOnly={false}
                     onClose={() => {}}
-                    open={true}
+                    open
                     selectAssetFromDisk={selectAssetFromDisk}
+                    importAsset={() => Promise.resolve('kapeta/other:local')}
                     missingReferences={[
                         {
                             type: ReferenceType.BLOCK,
                             blockRef: 'kapeta/todo:local',
                             ref: 'kapeta/todo:local',
+                            instanceId: InvalidPlannerData.spec.blocks[0].id,
                         },
                         {
                             type: ReferenceType.TARGET,
                             blockRef: 'kapeta/todo:local',
                             ref: 'kapeta/language-target-java-spring-boot:local',
+                            instanceId: InvalidPlannerData.spec.blocks[0].id,
                         },
                     ]}
                 />
@@ -232,9 +236,10 @@ export const CanNotResolve = () => {
                     plan={InvalidPlannerData}
                     blockAssets={blocks.value!.map(fromAsset)}
                     assetCanBeInstalled={() => Promise.resolve(false)}
-                    readOnly={true}
+                    readOnly
                     onClose={() => {}}
-                    open={true}
+                    open
+                    importAsset={() => Promise.resolve(null)}
                     selectAssetFromDisk={selectAssetFromDisk}
                     missingReferences={[
                         {


### PR DESCRIPTION
Now updates references in the plan, if the imported asset does not match the name
of the original. e.g. its possible to resolve with a block from another namespace or
name.
