### PR TITLE
fix: hide actionButtons behind resource body [KAP-2241]

### DIFF
--- a/src/planner/components/ActionButtons.tsx
+++ b/src/planner/components/ActionButtons.tsx
@@ -100,7 +100,9 @@ export const ActionButtons = (props: ActionButtonListProps) => {
                 transform: props.show
                     ? 'translateX(0px)'
                     : `translateX(${
-                          props.pointType === 'left' ? -buttonWidth * (buttonIx + 1) : width - buttonWidth * buttonIx
+                          props.pointType === 'left'
+                              ? -8 - buttonWidth * (buttonIx + 1)
+                              : width + 8 - buttonWidth * buttonIx
                       }px)`,
             };
         },


### PR DESCRIPTION
Tweaks the hidden state offset, to send buttons behind the resource.  This
regression happened when changing overflow to visible, since the buttons were
previously hidden by being "off canvas" in the foreignObject.
