### PR TITLE
fix: more stable layout of drawer resources [CORE-1180]

### DIFF
--- a/src/panels/PlannerDrawer.tsx
+++ b/src/panels/PlannerDrawer.tsx
@@ -9,7 +9,7 @@ import { Paper, Stack } from '@mui/material';
 export const PlannerDrawer = (props: React.PropsWithChildren) => {
     return (
         <Paper
-            data-kap-id={'plan-editor-resource-drawer'}
+            data-kap-id="plan-editor-resource-drawer"
             className="planner-resource-drawer"
             square
             variant="elevation"

--- a/src/panels/tools/BlockTypeToolList.tsx
+++ b/src/panels/tools/BlockTypeToolList.tsx
@@ -4,7 +4,7 @@
  */
 
 import { IBlockTypeProvider } from '@kapeta/ui-web-types';
-import { Box, Stack } from '@mui/material';
+import { Box, Grid, Stack } from '@mui/material';
 import React from 'react';
 import { BlockTypeTool } from './BlockTypeTool';
 
@@ -15,11 +15,15 @@ interface Props {
 export const BlockTypeToolList = (props: Props) => {
     return (
         <Box className="planner-block-type-list">
-            <Stack direction="row" alignItems="flex-start" flexWrap="wrap" gap={2}>
+            <Grid container spacing={2}>
                 {props.blockTypes.map((blockType, ix) => {
-                    return <BlockTypeTool key={`block-type-${ix}`} blockType={blockType} />;
+                    return (
+                        <Grid item xs={6}>
+                            <BlockTypeTool key={`block-type-${ix}`} blockType={blockType} />
+                        </Grid>
+                    );
                 })}
-            </Stack>
+            </Grid>
         </Box>
     );
 };

--- a/src/panels/tools/ResourceToolList.tsx
+++ b/src/panels/tools/ResourceToolList.tsx
@@ -4,7 +4,7 @@
  */
 
 import { IResourceTypeProvider, Point } from '@kapeta/ui-web-types';
-import { Divider, Portal, Stack, SxProps, Typography } from '@mui/material';
+import { Divider, Grid, Portal, Stack, SxProps, Typography } from '@mui/material';
 import { DragAndDrop } from '../../planner/utils/dndUtils';
 
 import React, { useState } from 'react';
@@ -62,52 +62,52 @@ export const ResourceToolList = (props: Props) => {
                         }}
                     />
                 </Stack>
-                <Stack
-                    direction="row"
-                    alignItems="flex-start"
-                    flexWrap="wrap"
+                <Grid
+                    container
                     sx={{
                         mt: 2,
                     }}
-                    gap={2}
+                    spacing={2}
                 >
                     {props.resources.map((resource, ix) => {
                         return (
-                            <DragAndDrop.Draggable
-                                key={`resource-${ix}`}
-                                disabled={false}
-                                data={{
-                                    type: PlannerPayloadType.RESOURCE_TYPE,
-                                    data: {
-                                        title: resource.title || resource.kind,
-                                        kind: resource.kind,
-                                        config: resource,
-                                    },
-                                }}
-                                onDragStart={(evt) => {
-                                    setDragging(resource);
-                                }}
-                                onDragEnd={(evt) => {
-                                    setDragging(undefined);
-                                    setDraggingPosition(null);
-                                    setDraggedDiff(null);
-                                }}
-                                onDrag={(evt) => {
-                                    setDraggingPosition({
-                                        x: evt.client.end.x,
-                                        y: evt.client.end.y,
-                                    });
-                                    setDraggedDiff(evt.diff);
-                                }}
-                                onDrop={(evt) => {}}
-                            >
-                                {(evt) => {
-                                    return <ResourceShape {...evt.componentProps} resource={resource} />;
-                                }}
-                            </DragAndDrop.Draggable>
+                            <Grid item xs={6}>
+                                <DragAndDrop.Draggable
+                                    key={`resource-${ix}`}
+                                    disabled={false}
+                                    data={{
+                                        type: PlannerPayloadType.RESOURCE_TYPE,
+                                        data: {
+                                            title: resource.title || resource.kind,
+                                            kind: resource.kind,
+                                            config: resource,
+                                        },
+                                    }}
+                                    onDragStart={(evt) => {
+                                        setDragging(resource);
+                                    }}
+                                    onDragEnd={(evt) => {
+                                        setDragging(undefined);
+                                        setDraggingPosition(null);
+                                        setDraggedDiff(null);
+                                    }}
+                                    onDrag={(evt) => {
+                                        setDraggingPosition({
+                                            x: evt.client.end.x,
+                                            y: evt.client.end.y,
+                                        });
+                                        setDraggedDiff(evt.diff);
+                                    }}
+                                    onDrop={(evt) => {}}
+                                >
+                                    {(evt) => {
+                                        return <ResourceShape {...evt.componentProps} resource={resource} />;
+                                    }}
+                                </DragAndDrop.Draggable>
+                            </Grid>
                         );
                     })}
-                </Stack>
+                </Grid>
             </Stack>
             {dragging && draggingPosition && (
                 <Portal>

--- a/src/panels/tools/ResourceToolList.tsx
+++ b/src/panels/tools/ResourceToolList.tsx
@@ -65,7 +65,7 @@ export const ResourceToolList = (props: Props) => {
                 <Grid
                     container
                     sx={{
-                        mt: 2,
+                        mt: 0,
                     }}
                     spacing={2}
                 >

--- a/stories/resource-drawer.stories.tsx
+++ b/stories/resource-drawer.stories.tsx
@@ -32,7 +32,8 @@ export const Empty = () => {
 export const DrawerTabs = () => {
     const [currentTab, setCurrentTab] = React.useState(0);
     return (
-        <div style={{ backgroundColor: 'gray' }}>
+        // Height 100% to be able to resize the drawer in storybook to test overflow
+        <div style={{ backgroundColor: 'gray', height: '100%' }}>
             <PlannerDrawer>
                 <Tabs value={currentTab} onChange={(_evt, value) => setCurrentTab(value)}>
                     <Tab value={0} label="Resources" />


### PR DESCRIPTION
Uses CSS grid instead of flexbox to layout the items in the resource drawer,
so that permanent scrollbars that take up space doesnt interfere with the
flow of elements.

Test by enabling permanent scrollbars in MacOS preferences or on windows on
smaller screen sizes.
