### PR TITLE
fix: Add key prop

### DIFF
--- a/src/panels/tools/BlockTypeToolList.tsx
+++ b/src/panels/tools/BlockTypeToolList.tsx
@@ -4,7 +4,7 @@
  */
 
 import { IBlockTypeProvider } from '@kapeta/ui-web-types';
-import { Box, Grid, Stack } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import React from 'react';
 import { BlockTypeTool } from './BlockTypeTool';
 
@@ -18,8 +18,8 @@ export const BlockTypeToolList = (props: Props) => {
             <Grid container spacing={2}>
                 {props.blockTypes.map((blockType, ix) => {
                     return (
-                        <Grid item xs={6}>
-                            <BlockTypeTool key={`block-type-${ix}`} blockType={blockType} />
+                        <Grid item xs={6} key={`block-type-${ix}`}>
+                            <BlockTypeTool blockType={blockType} />
                         </Grid>
                     );
                 })}

--- a/src/panels/tools/ResourceToolList.tsx
+++ b/src/panels/tools/ResourceToolList.tsx
@@ -71,9 +71,8 @@ export const ResourceToolList = (props: Props) => {
                 >
                     {props.resources.map((resource, ix) => {
                         return (
-                            <Grid item xs={6}>
+                            <Grid item xs={6} key={`resource-${ix}`}>
                                 <DragAndDrop.Draggable
-                                    key={`resource-${ix}`}
                                     disabled={false}
                                     data={{
                                         type: PlannerPayloadType.RESOURCE_TYPE,


### PR DESCRIPTION
Some `key` props were not moved to the new wrapper component in https://github.com/kapetacom/ui-web-plan-editor/pull/137 - fixing that here