### PR TITLE
feat: Add support for opening folder from resolution ui

### DIFF
--- a/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
+++ b/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
@@ -25,6 +25,7 @@ interface ReferenceResolverModalProps extends Omit<ReferenceResolverProps, 'onCh
      * @returns The new asset ref as a string or null if the import failed
      */
     importAsset?: (ref: string) => Promise<string | null>;
+    openExternal?: () => void; //Should open the project in an editor or file explorer
     inline?: boolean;
 }
 
@@ -139,6 +140,11 @@ export const ReferenceResolutionHandler = (props: Omit<ReferenceResolverModalPro
                 {props.onClose && (
                     <Button variant={unresolvable ? 'contained' : 'text'} onClick={props.onClose}>
                         {unresolvable ? 'Close' : 'Cancel'}
+                    </Button>
+                )}
+                {props.openExternal && (
+                    <Button variant={'text'} onClick={props.openExternal}>
+                        Open Plan
                     </Button>
                 )}
                 {applyButton}

--- a/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
+++ b/src/planner/reference-resolver/ReferenceResolutionHandler.tsx
@@ -15,9 +15,21 @@ import {
 } from '../validation/PlanResolutionTransformer';
 
 interface ReferenceResolverModalProps extends Omit<ReferenceResolverProps, 'onChange'> {
+    /**
+     * Whether the modal is open. Ignored if `inline` is true
+     */
     open: boolean;
+    /**
+     * Callback to close the modal. Ignored if `inline` is true
+     */
     onClose?: () => void;
+    /**
+     * Callback to handle the result of the resolution
+     */
     onResolved?: (result: PlanResolutionResult) => void | Promise<void>;
+    /**
+     * Callback to install an asset
+     */
     installAsset?: (ref: string) => Promise<void>;
     /**
      *
@@ -25,7 +37,13 @@ interface ReferenceResolverModalProps extends Omit<ReferenceResolverProps, 'onCh
      * @returns The new asset ref as a string or null if the import failed
      */
     importAsset?: (ref: string) => Promise<string | null>;
-    openExternal?: () => void; //Should open the project in an editor or file explorer
+    /**
+     * Should open the project in an editor or file explorer
+     */
+    openExternal?: () => void;
+    /**
+     * If true, will not render in a modal. Defaults to false
+     */
     inline?: boolean;
 }
 


### PR DESCRIPTION
Adds "Open plan" button to resolution UI to make it easy to jump to the code to resolve manually

![image](https://github.com/kapetacom/ui-web-plan-editor/assets/441655/e7b7f390-fe82-4e3a-b23b-7118cab84e5d)
