### PR TITLE
fix: add html title tooltips to resource names [CORE-2138]

### DIFF
--- a/src/planner/components/BlockResource.tsx
+++ b/src/planner/components/BlockResource.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { toClass, createHexagonPath, Orientation } from '@kapeta/ui-web-utils';
 
 import { ResourceRole } from '@kapeta/ui-web-types';
@@ -13,6 +13,7 @@ import { PlannerNodeSize } from '../../types';
 import './BlockResource.less';
 import { ActionContext } from '../types';
 import { BlockResourceIcon } from './BlockResourceIcon';
+import { Tooltip } from '@kapeta/ui-web-components';
 
 interface PlannerResourceProps {
     size?: PlannerNodeSize;
@@ -48,6 +49,12 @@ export const BlockResource = (props: PlannerResourceProps) => {
     });
 
     const maxTextWidth = width - 70;
+    const [hasOverflow, setHasOverflow] = React.useState(false);
+    const onRef = (el: HTMLSpanElement | null) => {
+        if (el) {
+            setHasOverflow(el.scrollWidth > el.offsetWidth);
+        }
+    };
 
     const padding = 8;
 
@@ -60,7 +67,17 @@ export const BlockResource = (props: PlannerResourceProps) => {
             )}
             <foreignObject width={maxTextWidth} className="block-resource-text resource-name" y={padding} x={textX}>
                 <plannerRenderer.Outlet id={PlannerOutlet.ResourceTitle} context={props.actionContext}>
-                    <span>{props.name}</span>
+                    {hasOverflow ? (
+                        <Tooltip
+                            title={props.name}
+                            // Estimate for overflow by string length
+                            placement={consumer ? 'bottom-end' : 'bottom-start'}
+                        >
+                            <span ref={onRef}>{props.name}</span>
+                        </Tooltip>
+                    ) : (
+                        <span ref={onRef}>{props.name}</span>
+                    )}
                 </plannerRenderer.Outlet>
             </foreignObject>
 

--- a/stories/resources.stories.tsx
+++ b/stories/resources.stories.tsx
@@ -99,6 +99,40 @@ export default {
     },
 };
 
+export const ResourceLongName = () => {
+    const resource: Resource = {
+        kind: 'kapeta/resource-type-rest-api:1.2.3',
+        metadata: {
+            name: 'This is a very long name that should be truncated',
+        },
+        spec: {
+            port: {
+                type: 'rest',
+            },
+        },
+    };
+    return (
+        <BlockContext.Provider
+            value={
+                {
+                    blockInstance: ValidInstance,
+                    blockReference: parseKapetaUri(ValidInstance.block.ref),
+                } as Partial<PlannerBlockContextData> as any
+            }
+        >
+            <div style={{ padding: '20px' }}>
+                <PlannerBlockResourceListItem
+                    size={PlannerNodeSize.FULL}
+                    index={0}
+                    mode={ResourceMode.SHOW}
+                    resource={resource}
+                    role={ResourceRole.PROVIDES}
+                />
+            </div>
+        </BlockContext.Provider>
+    );
+};
+
 export const ResourceMissingKind = () => {
     const resource = MissingResourceKind;
     const errors = new BlockValidator(ValidDefinition, ValidInstance).validateResource(resource);


### PR DESCRIPTION
It's not great but it's better than nothing for seeing the names.

<img width="343" alt="Screenshot 2024-03-14 at 16 47 55" src="https://github.com/kapetacom/ui-web-plan-editor/assets/296057/3e9bd642-bb4d-42a4-9836-3c7343daa1d6">
