### PR TITLE
fix: include block offsets in initial drag position calculations [CORE-3020]

### DIFF
--- a/src/planner/PlannerCanvas.tsx
+++ b/src/planner/PlannerCanvas.tsx
@@ -31,8 +31,9 @@ const toBlockPoint = (mousePoint: Point, zoom: number): Point => {
 
 const blockPositionUpdater = (diff: Point, zoom: number) => (block: BlockInstance) => {
     const point = toBlockPoint(diff, zoom);
-    point.x += block.dimensions!.left;
-    point.y += block.dimensions!.top;
+    const originalPosition = adjustBlockEdges({ x: block.dimensions.left, y: block.dimensions.top });
+    point.x += originalPosition.x;
+    point.y += originalPosition.y;
     adjustBlockEdges(point);
 
     return {

--- a/src/planner/components/PlannerBlockNode.tsx
+++ b/src/planner/components/PlannerBlockNode.tsx
@@ -212,9 +212,13 @@ const PlannerBlockNodeBase: React.FC<Props> = (props: Props) => {
             }}
         >
             {(evt) => {
+                const startPoint = adjustBlockEdges({
+                    x: blockContext.blockInstance.dimensions!.left,
+                    y: blockContext.blockInstance.dimensions!.top,
+                });
                 let point: Point = adjustBlockEdges({
-                    x: blockContext.blockInstance.dimensions!.left + evt.zone.diff.x / planner.zoom,
-                    y: blockContext.blockInstance.dimensions!.top + evt.zone.diff.y / planner.zoom,
+                    x: startPoint.x + evt.zone.diff.x / planner.zoom,
+                    y: startPoint.y + evt.zone.diff.y / planner.zoom,
                 });
 
                 if (focusInfo) {


### PR DESCRIPTION
Should fix the "block doesnt move" issue on first drag when the block position starts at 0,0.