### PR TITLE
Dark mode support for the Planner (Blocks, Resources, Connections)

### DIFF
--- a/src/planner/Planner.less
+++ b/src/planner/Planner.less
@@ -114,7 +114,6 @@
 
 .planner-area-canvas {
     .no-select();
-    .transition();
     background-color: @bw-planner-background;
     position: relative;
     transform-origin: 0px 0px;

--- a/src/planner/components/ActionButtons.tsx
+++ b/src/planner/components/ActionButtons.tsx
@@ -10,17 +10,60 @@ import { staggeredFade } from '../utils/transitionUtils';
 import './ActionButtons.less';
 import { usePrevious } from 'react-use';
 import { toClass } from '@kapeta/ui-web-utils';
+import { Box } from '@mui/material';
 
 const CircleButton = (props: any) => {
     // NOTE: A bit strange - but this has to be a div to not experience a UI glitch where the button
     // receives some sort of focus and is moved into view when closing the sidepanel it opens
     return (
-        <div
+        <Box
             data-kap-id={props['data-kap-id']}
             onClick={props.onClick}
             className={`svg-circle-button ${props.className}`}
             style={{ padding: 0, border: 0, background: 'none', ...(props.style || {}) }}
             title={props.label}
+            sx={(theme) => {
+                const isDarkMode = theme.palette.mode === 'dark';
+                return {
+                    ...(isDarkMode
+                        ? {
+                              '&&&': {
+                                  '.bg-container': {
+                                      backgroundColor: '#474747',
+                                  },
+                                  '.container': {
+                                      backgroundColor: '#474747',
+                                      color: 'white',
+                                      borderColor: '#717171',
+                                      '&:hover, &:active': {
+                                          background: '#060303',
+                                      },
+                                  },
+                                  '&.primary .container': {
+                                      '&:hover, &:active': {
+                                          background: theme.palette.primary.main,
+                                          borderColor: 'transparent',
+                                      },
+                                  },
+
+                                  '&.secondary .container': {
+                                      '&:hover, &:active': {
+                                          background: theme.palette.secondary.main,
+                                          borderColor: 'transparent',
+                                      },
+                                  },
+
+                                  '&.danger .container': {
+                                      '&:hover, &:active': {
+                                          background: theme.palette.error.light,
+                                          borderColor: 'transparent',
+                                      },
+                                  },
+                              },
+                          }
+                        : {}),
+                };
+            }}
         >
             {/* White opaque background to avoid opacity in colors looking weird on top of connections */}
             <div className="bg-container">
@@ -28,7 +71,7 @@ const CircleButton = (props: any) => {
                     <i className={props.icon} />
                 </div>
             </div>
-        </div>
+        </Box>
     );
 };
 

--- a/src/planner/components/BlockResource.tsx
+++ b/src/planner/components/BlockResource.tsx
@@ -80,7 +80,16 @@ export const BlockResource = (props: PlannerResourceProps) => {
     }
 
     return (
-        <g className={resourceClass}>
+        <Box
+            component="g"
+            className={resourceClass}
+            sx={(theme) => {
+                const isDarkMode = theme.palette.mode === 'dark';
+                return {
+                    ...(isDarkMode ? { '&&& .block-resource-text': { color: 'white' } } : {}),
+                };
+            }}
+        >
             {props.type === 'operator' ? (
                 <Box
                     component="rect"
@@ -90,7 +99,27 @@ export const BlockResource = (props: PlannerResourceProps) => {
                     rx="3"
                     ry="3"
                     x="3"
-                    sx={highlight ? { '&&': { stroke: '#651FFF', strokeWidth: 3, strokeOpacity: 1 } } : {}}
+                    sx={(theme) => ({
+                        ...(highlight
+                            ? {
+                                  '&&': {
+                                      stroke: '#651FFF',
+                                      strokeWidth: 3,
+                                      strokeOpacity: 1,
+                                  },
+                              }
+                            : {}),
+                        ...(theme.palette.mode === 'dark'
+                            ? {
+                                  '&&&': {
+                                      fill: '#212425',
+                                      stroke: '#727272',
+                                      strokeOpacity: 1,
+                                      strokeWidth: 1,
+                                  },
+                              }
+                            : {}),
+                    })}
                 />
             ) : (
                 <Box
@@ -100,7 +129,27 @@ export const BlockResource = (props: PlannerResourceProps) => {
                     strokeLinejoin="round"
                     rx="3"
                     ry="3"
-                    sx={highlight ? { '&&': { stroke: '#651FFF', strokeWidth: 3, strokeOpacity: 1 } } : {}}
+                    sx={(theme) => ({
+                        ...(highlight
+                            ? {
+                                  '&&': {
+                                      stroke: '#651FFF',
+                                      strokeWidth: 3,
+                                      strokeOpacity: 1,
+                                  },
+                              }
+                            : {}),
+                        ...(theme.palette.mode === 'dark'
+                            ? {
+                                  '&&&': {
+                                      fill: '#212425',
+                                      stroke: '#727272',
+                                      strokeOpacity: 1,
+                                      strokeWidth: 1,
+                                  },
+                              }
+                            : {}),
+                    })}
                 />
             )}
             <foreignObject width={maxTextWidth} className="block-resource-text resource-name" y={padding} x={textX}>
@@ -126,9 +175,21 @@ export const BlockResource = (props: PlannerResourceProps) => {
             </foreignObject>
 
             {props.icon ? (
-                <foreignObject x={iconX} y={height / 2 - 10} width={20} height={20}>
+                <Box
+                    component="foreignObject"
+                    x={iconX}
+                    y={height / 2 - 10}
+                    width={20}
+                    height={20}
+                    sx={(theme) => {
+                        const isDarkMode = theme.palette.mode === 'dark';
+                        return {
+                            ...(isDarkMode ? { '&&&': { filter: 'invert(1) brightness(2) contrast(1.5)' } } : {}),
+                        };
+                    }}
+                >
                     {props.icon}
-                </foreignObject>
+                </Box>
             ) : (
                 <BlockResourceIcon
                     x={iconX}
@@ -138,6 +199,6 @@ export const BlockResource = (props: PlannerResourceProps) => {
                     color={props.typeStatusColor}
                 />
             )}
-        </g>
+        </Box>
     );
 };

--- a/src/planner/components/PlannerBlockNode.tsx
+++ b/src/planner/components/PlannerBlockNode.tsx
@@ -29,7 +29,7 @@ import './PlannerBlockNode.less';
 import { withErrorBoundary } from 'react-error-boundary';
 import { Resource } from '@kapeta/schemas';
 import { KapetaURI, parseKapetaUri } from '@kapeta/nodejs-utils';
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { useAtomValue } from 'jotai';
 
 export function adjustBlockEdges(point: Point) {
@@ -200,6 +200,8 @@ const PlannerBlockNodeBase: React.FC<Props> = (props: Props) => {
     ) {
         highlight = true;
     }
+
+    const isDarkMode = useTheme().palette.mode === 'dark';
 
     return (
         // TODO: Readonly/ viewonly
@@ -438,17 +440,60 @@ const PlannerBlockNodeBase: React.FC<Props> = (props: Props) => {
                                             component="g"
                                             {...evt.componentProps}
                                             ref={onRef}
-                                            sx={
-                                                highlight
+                                            sx={(theme) => ({
+                                                ...(highlight
                                                     ? {
                                                           '&& .block-node > .block-border': {
-                                                              stroke: '#651FFF',
-                                                              strokeWidth: 3,
-                                                              strokeOpacity: 1,
+                                                              stroke: `${theme.palette.primary.main} !important`,
+                                                              strokeWidth: `${3} !important`,
+                                                              strokeOpacity: `${1} !important`,
                                                           },
                                                       }
-                                                    : {}
-                                            }
+                                                    : {}),
+                                                ...(isDarkMode
+                                                    ? {
+                                                          '&& .block-node': {
+                                                              '> .block-body': {
+                                                                  fill: '#212425',
+                                                              },
+                                                              '> .block-border': {
+                                                                  stroke: '#727272',
+                                                                  strokeWidth: 1.5,
+                                                                  strokeOpacity: 1,
+                                                              },
+                                                              '.block-body-text': {
+                                                                  '&.instance-name': {
+                                                                      fill: '#ffffff',
+                                                                  },
+                                                                  '&.block-name, &.block-version, &.block-handle': {
+                                                                      fill: '#CBCBCB',
+                                                                  },
+                                                              },
+                                                              'circle.instance_failed': {
+                                                                  fill: theme.palette.error.main,
+                                                              },
+                                                              'circle.instance_busy': {
+                                                                  fill: theme.palette.warning.main,
+                                                              },
+                                                              'circle.instance_stopped': {
+                                                                  fill: '#727272',
+                                                              },
+                                                              'circle.instance_stopping': {
+                                                                  fill: '#727272',
+                                                              },
+                                                              'circle.instance_ready': {
+                                                                  fill: theme.palette.success.main,
+                                                              },
+                                                              'circle.instance_unhealthy': {
+                                                                  fill: theme.palette.warning.main,
+                                                              },
+                                                              'circle.instance_starting': {
+                                                                  fill: theme.palette.success.main,
+                                                              },
+                                                          },
+                                                      }
+                                                    : {}),
+                                            })}
                                         >
                                             {blockContext.blockDefinition ? (
                                                 <BlockLayout

--- a/src/planner/components/PlannerBlockResourceListItem.tsx
+++ b/src/planner/components/PlannerBlockResourceListItem.tsx
@@ -27,6 +27,7 @@ import { PlannerMode, ResourceMode } from '../../utils/enums';
 import { parseKapetaUri } from '@kapeta/nodejs-utils';
 import { AssetKindIcon } from '@kapeta/ui-web-components';
 import { useBlockEntities } from '../hooks/useBlockEntitiesForResource';
+import { Box } from '@mui/material';
 
 export const RESOURCE_SPACE = 4; // Vertical distance between resources
 const COUNTER_SIZE = 8;
@@ -479,7 +480,32 @@ export const PlannerBlockResourceListItem: React.FC<PlannerBlockResourceListItem
                                     x={counterPoint.x}
                                     y={counterPoint.y}
                                 >
-                                    <g className="resource-counter">
+                                    <Box
+                                        component="g"
+                                        className="resource-counter"
+                                        sx={(theme) => {
+                                            const isDarkMode = theme.palette.mode === 'dark';
+                                            return {
+                                                '&&&': {
+                                                    '.background': {
+                                                        ...(isDarkMode
+                                                            ? {
+                                                                  fill: theme.palette.success.light,
+                                                                  stroke: '#212425',
+                                                              }
+                                                            : {}),
+                                                    },
+                                                    '.foreground': {
+                                                        ...(isDarkMode
+                                                            ? {
+                                                                  fill: theme.palette.text.primary,
+                                                              }
+                                                            : {}),
+                                                    },
+                                                },
+                                            };
+                                        }}
+                                    >
                                         <circle
                                             cx={COUNTER_SIZE}
                                             cy={COUNTER_SIZE}
@@ -489,7 +515,7 @@ export const PlannerBlockResourceListItem: React.FC<PlannerBlockResourceListItem
                                         <text textAnchor="middle" className="foreground" y={12} x={COUNTER_SIZE}>
                                             {counterValue}
                                         </text>
-                                    </g>
+                                    </Box>
                                 </svg>
                             </g>
                         </svg>

--- a/src/planner/components/PlannerConnection.less
+++ b/src/planner/components/PlannerConnection.less
@@ -50,10 +50,6 @@
     }
 
     &.highlight {
-        .line {
-            stroke: #651fff;
-        }
-
         g.portal {
             fill: #651fff;
         }
@@ -64,11 +60,6 @@
     }
 
     &.invalid {
-        .line {
-            stroke-dasharray: 5;
-            stroke: @status-danger-bg;
-        }
-
         &.highlight {
             .line {
                 stroke: darken(@status-danger-bg, 15%);

--- a/src/planner/components/PlannerConnection.less
+++ b/src/planner/components/PlannerConnection.less
@@ -19,7 +19,6 @@
     }
 
     .line {
-        .transition();
         stroke: @kapeta-success-light;
         stroke-width: 3;
         stroke-linecap: round;
@@ -27,7 +26,6 @@
 
     .background {
         fill: none;
-        .transition();
         stroke: @bw-planner-background;
         stroke-width: 6;
         stroke-linecap: round;

--- a/src/planner/components/PlannerConnection.tsx
+++ b/src/planner/components/PlannerConnection.tsx
@@ -33,6 +33,7 @@ import {
 import { applyObstacles } from '../utils/connectionUtils/src/matrix';
 import _ from 'lodash';
 import { useBlockEntities, useTransformEntities } from '../hooks/useBlockEntitiesForResource';
+import { Box } from '@mui/material';
 
 const CLUSTER_INDEX_OFFSET = 10;
 const ENABLE_CLUSTERING = true;
@@ -103,6 +104,7 @@ export const PlannerConnection: React.FC<{
     // eslint-disable-next-line react/no-unused-prop-types
     size: PlannerNodeSize;
     className?: string;
+    highlight?: boolean;
     // eslint-disable-next-line react/no-unused-prop-types
     viewOnly?: boolean;
     focused?: boolean;
@@ -421,7 +423,17 @@ export const PlannerConnection: React.FC<{
                     return (
                         <g key={ix}>
                             <path className="mouse-catcher" d={pathInfo.path} />
-                            <path className="background" d={pathInfo.path} />
+                            <Box
+                                component="path"
+                                className="background"
+                                d={pathInfo.path}
+                                sx={(theme) => {
+                                    const isDarkMode = theme.palette.mode === 'dark';
+                                    return {
+                                        ...(isDarkMode ? { '&&&': { stroke: '#212425' } } : {}),
+                                    };
+                                }}
+                            />
 
                             {behaveAsPortal && pathInfo.portalPoint && (
                                 <svg
@@ -437,7 +449,22 @@ export const PlannerConnection: React.FC<{
                                 </svg>
                             )}
 
-                            <path className="line" d={pathInfo.path} />
+                            <Box
+                                component="path"
+                                className="line"
+                                d={pathInfo.path}
+                                sx={(theme) => {
+                                    const validColor = props.highlight
+                                        ? theme.palette.primary.main
+                                        : theme.palette.success.main;
+                                    return {
+                                        '&&&': {
+                                            stroke: connectionValid ? validColor : theme.palette.error.light,
+                                            strokeDasharray: connectionValid ? 'none' : '5 5',
+                                        },
+                                    };
+                                }}
+                            />
 
                             {props.actions && (
                                 <ActionButtons

--- a/src/planner/components/PlannerConnections.tsx
+++ b/src/planner/components/PlannerConnections.tsx
@@ -186,6 +186,7 @@ export const PlannerConnections = (props: Props) => {
                         style={{ zIndex: highlighted ? -1 : showPortal ? -40 : -50 }}
                         size={props.nodeSize}
                         className={className}
+                        highlight={highlighted}
                         connection={connection}
                         actions={props.actions?.connection || []}
                         onMouseOver={props.onConnectionMouseEnter}

--- a/stories/data/BlockServiceMock.tsx
+++ b/stories/data/BlockServiceMock.tsx
@@ -306,9 +306,11 @@ BlockTypeProvider.register({
         return (
             <g className="block-node" style={{ cursor: block.readOnly ? 'default' : 'move' }}>
                 {/* Background */}
-                <rect width={props.width} height={props.height} rx="6" fill="white" />
+                <rect className="block-body" width={props.width} height={props.height} rx="6" fill="white" />
+
                 {/* Border */}
                 <rect
+                    className="block-border"
                     x="0.5"
                     y="0.5"
                     width={props.width - 1}
@@ -397,9 +399,19 @@ BlockTypeProvider.register({
         return (
             <g className="block-node" style={{ cursor: block.readOnly ? 'default' : 'move' }}>
                 {/* Background */}
-                <rect x={0} y={0} width={props.width} fill="white" height={props.height} rx="5px" ry="5px" />
+                <rect
+                    className="block-body"
+                    x={0}
+                    y={0}
+                    width={props.width}
+                    fill="white"
+                    height={props.height}
+                    rx="5px"
+                    ry="5px"
+                />
                 {/* Border */}
                 <rect
+                    className="block-border"
                     x="0.5"
                     y="0.5"
                     width={props.width - 1}


### PR DESCRIPTION
Note: Icons will be fixed in https://kapeta.atlassian.net/browse/CORE-3097 - right now we use a CSS filter that doesn't look good (e.g. the mongo logo in this screenshot)

<img width="1001" alt="Screenshot 2024-06-25 at 12 54 56" src="https://github.com/kapetacom/ui-web-plan-editor/assets/1045799/2bd02a74-6efb-44e7-81f7-fac3dc5d66ea">
