### PR TITLE
CORE-3138 PlannerDrawer style tweak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
             },
             "devDependencies": {
                 "@jest/globals": "^29.7.0",
-                "@kapeta/kaplang-core": "^1.13.0",
+                "@kapeta/kaplang-core": "^1.17.2",
                 "@kapeta/nodejs-utils": "^0.1.3",
                 "@kapeta/prettier-config": "^0.6.2",
                 "@kapeta/style": "^0.94.0",
@@ -58,10 +58,10 @@
                 "yaml-loader": "^0.8.0"
             },
             "peerDependencies": {
-                "@kapeta/kaplang-core": "^1.14.1",
-                "@kapeta/nodejs-utils": "<2",
-                "@kapeta/schemas": "^3.6.0",
-                "@kapeta/ui-web-components": "^3.5.4",
+                "@kapeta/kaplang-core": "^1.17.2",
+                "@kapeta/nodejs-utils": "^0.1.3",
+                "@kapeta/schemas": "^3.6.1",
+                "@kapeta/ui-web-components": "^3.11.0",
                 "@kapeta/ui-web-context": "^1.2.5",
                 "@kapeta/ui-web-types": "^1.3.3",
                 "@kapeta/ui-web-utils": ">=0.0.29 <2",
@@ -4019,9 +4019,9 @@
             "dev": true
         },
         "node_modules/@kapeta/kaplang-core": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@kapeta/kaplang-core/-/kaplang-core-1.14.1.tgz",
-            "integrity": "sha512-/tTsfQ9MPnv5KGx+LoQTaZki3nP2W720GslzBtjS8ifId8mmTmWaEzIjybhhtClEx8wc/mrOR7+BQffO3v8MKw==",
+            "version": "1.17.2",
+            "resolved": "https://registry.npmjs.org/@kapeta/kaplang-core/-/kaplang-core-1.17.2.tgz",
+            "integrity": "sha512-cvyJZax6Y5BbH0kRudeUjpwQ87pVEXP1p3KcXf1sWN4JJtKvH/vHhJJBnVucSKtCVLnM7DhO2H+5LWkdB41tZg==",
             "peerDependencies": {
                 "@kapeta/schemas": "^3",
                 "lodash": "^4"
@@ -4047,9 +4047,9 @@
             }
         },
         "node_modules/@kapeta/schemas": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@kapeta/schemas/-/schemas-3.6.0.tgz",
-            "integrity": "sha512-f44ek+UKYaCiWpIaSMpicUFMUwGFcEB84siz/kacrYT444x/4EXL+ljzsNV2iwmm5vCHQ9oOSSshLGg5SjdcvA==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@kapeta/schemas/-/schemas-3.6.1.tgz",
+            "integrity": "sha512-aAG4FvDwYkjlAjj+CqMbtZKLm49YUIQqwsauF3H30NS0twFhlccipW1/YXYaydeyjmVEjINKM/rvSVTBROK58Q==",
             "peer": true,
             "dependencies": {
                 "ajv": "^8.12.0",
@@ -4062,9 +4062,9 @@
             "integrity": "sha512-mafdrXCc2mtq5oY2sIj+bAJf1epGrh2mz3mwFf2u+Gii/2Mh/urjtpgXv99simQHVk6xNPb/s49GvvxTvE3erQ=="
         },
         "node_modules/@kapeta/ui-web-components": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-components/-/ui-web-components-3.5.4.tgz",
-            "integrity": "sha512-4QIF7B0OOkwxcXHJi1C4nJfM4DmNIEKhPu4qGXGe4Ic3mZeJiLN5aNDsAFdRikG+OB/GgAkiGly4bL5DoiBkhg==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/@kapeta/ui-web-components/-/ui-web-components-3.11.0.tgz",
+            "integrity": "sha512-YT/lEt5sEZnJAIWzqs43Gi4OfIjj29VuoL15gzm65tqNi3gan0saRVsfCD3SKvsqXGiRnrhFyweLwzWOUHKBwQ==",
             "peer": true,
             "dependencies": {
                 "@kapeta/nodejs-utils": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     },
     "prettier": "@kapeta/prettier-config",
     "peerDependencies": {
-        "@kapeta/kaplang-core": "^1.14.1",
-        "@kapeta/nodejs-utils": "<2",
-        "@kapeta/schemas": "^3.6.0",
-        "@kapeta/ui-web-components": "^3.5.4",
+        "@kapeta/kaplang-core": "^1.17.2",
+        "@kapeta/nodejs-utils": "^0.1.3",
+        "@kapeta/schemas": "^3.6.1",
+        "@kapeta/ui-web-components": "^3.11.0",
         "@kapeta/ui-web-context": "^1.2.5",
         "@kapeta/ui-web-types": "^1.3.3",
         "@kapeta/ui-web-utils": ">=0.0.29 <2",
@@ -69,7 +69,7 @@
     },
     "devDependencies": {
         "@jest/globals": "^29.7.0",
-        "@kapeta/kaplang-core": "^1.13.0",
+        "@kapeta/kaplang-core": "^1.17.2",
         "@kapeta/nodejs-utils": "^0.1.3",
         "@kapeta/prettier-config": "^0.6.2",
         "@kapeta/style": "^0.94.0",

--- a/src/panels/PlannerDrawer.tsx
+++ b/src/panels/PlannerDrawer.tsx
@@ -4,9 +4,13 @@
  */
 
 import React from 'react';
-import { Paper, Stack } from '@mui/material';
+import { Paper, PaperProps, Stack } from '@mui/material';
 
-export const PlannerDrawer = (props: React.PropsWithChildren) => {
+export interface PlannerDrawerProps extends PaperProps {}
+
+export const PlannerDrawer = (props: PlannerDrawerProps) => {
+    const { sx, children, ...paperProps } = props;
+
     return (
         <Paper
             data-kap-id="plan-editor-resource-drawer"
@@ -14,16 +18,18 @@ export const PlannerDrawer = (props: React.PropsWithChildren) => {
             square
             variant="elevation"
             sx={{
-                p: 2,
                 width: '284px',
                 height: '100%',
                 boxSizing: 'border-box',
                 flexShrink: 0,
-                overflowY: 'auto',
+                ...sx,
             }}
             elevation={2}
+            {...paperProps}
         >
-            <Stack direction="column">{props.children}</Stack>
+            <Stack direction="column" sx={{ height: '100%' }}>
+                {children}
+            </Stack>
         </Paper>
     );
 };

--- a/src/panels/tools/PlannerResourcesList.tsx
+++ b/src/panels/tools/PlannerResourcesList.tsx
@@ -43,7 +43,7 @@ export const PlannerResourcesList = (props: Props) => {
     }, []);
 
     return (
-        <Stack gap={4} sx={{ py: 3 }}>
+        <Stack gap={4}>
             <Stack className="resources" data-kap-id="plan-editor-resource-container" gap={2}>
                 <Typography
                     fontSize={HEADER_SIZE}


### PR DESCRIPTION
Moving `overflow` out of PlannerDrawer so the desktop can use nice scrollbars

![image](https://github.com/kapetacom/ui-web-plan-editor/assets/1045799/c12990fb-476f-487c-be4c-91a49785aa05)
